### PR TITLE
Adapt the test cases to match the strings used by Tidy 5.1.34

### DIFF
--- a/testbase/msg_1002509.txt
+++ b/testbase/msg_1002509.txt
@@ -6,14 +6,18 @@ line 20 column 2 - Warning: trimming empty <noframes>
 line 19 column 1 - Warning: trimming empty <frameset>
 Info: Doctype given is "-//W3C//DTD HTML 4.01 Frameset//EN"
 Info: Document content looks like HTML 4.01 Frameset
-5 warnings, 1 error were found!
+Tidy found 5 warnings and 1 error!
 
 This document has errors that must be fixed before
 using HTML Tidy to generate a tidied up version.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1003361.txt
+++ b/testbase/msg_1003361.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1004051.txt
+++ b/testbase/msg_1004051.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1004512.txt
+++ b/testbase/msg_1004512.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1014993.txt
+++ b/testbase/msg_1014993.txt
@@ -6,7 +6,7 @@ line 8 column 5 - Warning: trimming empty <font>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-5 warnings, 0 errors were found!
+Tidy found 5 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -15,7 +15,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1015959.txt
+++ b/testbase/msg_1015959.txt
@@ -5,7 +5,7 @@ line 10 column 1 - Warning: discarding unexpected </font>
 line 7 column 1 - Warning: trimming empty <font>
 Info: Doctype given is "-//W3C//DTD HTML 3.2//EN"
 Info: Document content looks like HTML 3.2
-5 warnings, 0 errors were found!
+Tidy found 5 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -14,7 +14,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1027888.txt
+++ b/testbase/msg_1027888.txt
@@ -2,11 +2,15 @@ line 5 column 1 - Warning: inserting implicit <body>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Strict
 Info: No system identifier in emitted doctype
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1050673.txt
+++ b/testbase/msg_1050673.txt
@@ -12,11 +12,15 @@ line 3 column 1 - Warning: trimming empty <li>
 line 2 column 1 - Warning: trimming empty <ul>
 line 4 column 1 - Warning: trimming empty <b>
 Info: Document content looks like HTML5
-13 warnings, 0 errors were found!
+Tidy found 13 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1052758.txt
+++ b/testbase/msg_1052758.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1053626.txt
+++ b/testbase/msg_1053626.txt
@@ -12,7 +12,7 @@ line 7 column 1 - Warning: trimming empty <noframes>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-10 warnings, 0 errors were found!
+Tidy found 10 warnings and 0 errors!
 
 The table summary attribute should be used to describe
 the table structure. It is very helpful for people using
@@ -25,7 +25,11 @@ For further advice on how to make your pages accessible
 see http://www.w3.org/WAI/GL.
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1055304.txt
+++ b/testbase/msg_1055304.txt
@@ -2,7 +2,7 @@ line 8 column 1 - Warning: <img> should use client-side image map
 line 9 column 14 - Warning: <img> should use client-side image map
 Info: Doctype given is "-//W3C//DTD HTML 4.01 Transitional//EN"
 Info: Document content looks like HTML 4.01 Transitional
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 Use client-side image maps in preference to server-side image
 maps as the latter are inaccessible to people using non-
@@ -13,7 +13,11 @@ For further advice on how to make your pages accessible
 see http://www.w3.org/WAI/GL.
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1055398.txt
+++ b/testbase/msg_1055398.txt
@@ -4,7 +4,7 @@ line 8 column 1 - Warning: missing </font> before </body>
 line 8 column 1 - Warning: <font> proprietary attribute "onload"
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML Proprietary
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -13,7 +13,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1056023.txt
+++ b/testbase/msg_1056023.txt
@@ -9,11 +9,15 @@ line 1 column 1 - Warning: inserting missing 'title' element
 line 1 column 1 - Warning: trimming empty <tfoot>
 line 1 column 1 - Warning: trimming empty <table>
 Info: Document content looks like HTML5
-9 warnings, 0 errors were found!
+Tidy found 9 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1056910.txt
+++ b/testbase/msg_1056910.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1062345.txt
+++ b/testbase/msg_1062345.txt
@@ -3,11 +3,15 @@ line 5 column 1 - Warning: <br> joining values of repeated attribute "style"
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1062511.txt
+++ b/testbase/msg_1062511.txt
@@ -12,11 +12,15 @@ line 3 column 1 - Warning: content occurs after end of body
 line 3 column 1 - Warning: trimming empty <marquee>
 line 6 column 1 - Warning: trimming empty <b>
 Info: Document content looks like HTML5
-12 warnings, 0 errors were found!
+Tidy found 12 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1062661.txt
+++ b/testbase/msg_1062661.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 6 column 37 - Warning: unescaped & or unknown entity "&tab"
 line 5 column 1 - Warning: trimming empty <script>
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1063256.txt
+++ b/testbase/msg_1063256.txt
@@ -12,7 +12,7 @@ line 5 column 1 - Warning: missing </noframes>
 line 1 column 1 - Warning: inserting missing 'title' element
 line 8 column 1 - Warning: trimming empty <tr>
 Info: Document content looks like HTML5
-10 warnings, 1 error were found!
+Tidy found 10 warnings and 1 error!
 
 This document has errors that must be fixed before
 using HTML Tidy to generate a tidied up version.
@@ -23,7 +23,11 @@ The proprietary <SPACER> element has limited vendor support.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1068087.txt
+++ b/testbase/msg_1068087.txt
@@ -3,7 +3,7 @@ line 6 column 4 - Warning: inserting implicit <font>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -12,7 +12,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1069549.txt
+++ b/testbase/msg_1069549.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1069553.txt
+++ b/testbase/msg_1069553.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1072528.txt
+++ b/testbase/msg_1072528.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: discarding malformed <!DOCTYPE>
 line 2 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1078345.txt
+++ b/testbase/msg_1078345.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1079820.txt
+++ b/testbase/msg_1079820.txt
@@ -5,11 +5,15 @@ line 44 column 1 - Warning: nested emphasis <u>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1086083.txt
+++ b/testbase/msg_1086083.txt
@@ -9,11 +9,15 @@ line 16 column 1 - Warning: missing </ul>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Strict
 Info: No system identifier in emitted doctype
-7 warnings, 0 errors were found!
+Tidy found 7 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1090318.txt
+++ b/testbase/msg_1090318.txt
@@ -2,11 +2,15 @@ line 9 column 1 - Warning: discarding unexpected <p>
 Info: Doctype given is "-//W3C//DTD HTML 4.01 Frameset//EN"
 Info: Document content looks like HTML 4.01 Frameset
 Info: No system identifier in emitted doctype
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1098012.txt
+++ b/testbase/msg_1098012.txt
@@ -12,7 +12,7 @@ line 6 column 1 - Warning: trimming empty <table>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-10 warnings, 0 errors were found!
+Tidy found 10 warnings and 0 errors!
 
 The table summary attribute should be used to describe
 the table structure. It is very helpful for people using
@@ -25,7 +25,11 @@ For further advice on how to make your pages accessible
 see http://www.w3.org/WAI/GL.
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1107622.txt
+++ b/testbase/msg_1107622.txt
@@ -1,11 +1,15 @@
 line 8 column 1 - Warning: <a> id and name attribute value mismatch
 Info: Doctype given is "-//W3C//DTD XHTML 1.0 Strict//EN"
 Info: Document content looks like XHTML 1.0 Strict
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1115094.txt
+++ b/testbase/msg_1115094.txt
@@ -3,11 +3,15 @@ line 7 column 6 - Warning: trimming empty <b>
 Info: Doctype given is "-//W3C//DTD HTML 3.2//EN"
 Info: Document content looks like HTML 4.01 Strict
 Info: No system identifier in emitted doctype
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1117013.txt
+++ b/testbase/msg_1117013.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1145571.txt
+++ b/testbase/msg_1145571.txt
@@ -2,11 +2,15 @@ line 8 column 1 - Warning: <a> cannot copy name attribute to id
 Info: Doctype given is "-//W3C//DTD HTML 4.01 Transitional//EN"
 Info: Document content looks like HTML 4.01 Strict
 Info: No system identifier in emitted doctype
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1145572.txt
+++ b/testbase/msg_1145572.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1168193.txt
+++ b/testbase/msg_1168193.txt
@@ -2,11 +2,15 @@ line 5 column 1 - Warning: inserting implicit <body>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Strict
 Info: No system identifier in emitted doctype
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1183751.txt
+++ b/testbase/msg_1183751.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1198501.txt
+++ b/testbase/msg_1198501.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1207443.txt
+++ b/testbase/msg_1207443.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1210752.txt
+++ b/testbase/msg_1210752.txt
@@ -3,11 +3,15 @@ line 1 column 1 - Warning: inserting implicit <body>
 line 1 column 1 - Warning: inserting missing 'title' element
 line 1 column 1 - Warning: trimming empty <p>
 Info: Document content looks like XHTML5
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1231279.txt
+++ b/testbase/msg_1231279.txt
@@ -1,11 +1,15 @@
 line 10 column 1 - Warning: <div> anchor "aBcDeF" already defined
 Info: Doctype given is "-//W3C//DTD HTML 4.01 Transitional//EN"
 Info: Document content looks like HTML 4.01 Strict
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1235296.txt
+++ b/testbase/msg_1235296.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1241723.txt
+++ b/testbase/msg_1241723.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1263391.txt
+++ b/testbase/msg_1263391.txt
@@ -1,11 +1,15 @@
 line 26 column 4 - Warning: <address> anchor "contact_autre" already defined
 Info: Doctype given is "-//W3C//DTD XHTML 1.0 Strict//EN"
 Info: Document content looks like XHTML 1.0 Transitional
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1266647.txt
+++ b/testbase/msg_1266647.txt
@@ -1,11 +1,15 @@
 line 1 column 5 - Warning: adjacent hyphens within comment
 line 3 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1282835.txt
+++ b/testbase/msg_1282835.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1286029.txt
+++ b/testbase/msg_1286029.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1286278.txt
+++ b/testbase/msg_1286278.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1316258.txt
+++ b/testbase/msg_1316258.txt
@@ -2,11 +2,15 @@ line 12 column 1 - Warning: discarding unexpected </center>
 Info: Doctype given is "-//W3C//DTD HTML 4.0 Transitional//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1316307-2.txt
+++ b/testbase/msg_1316307-2.txt
@@ -6,7 +6,7 @@ line 7 column 1 - Warning: trimming empty <ul>
 Info: Doctype given is "-//W3C//DTD HTML 4.0 Transitional//EN"
 Info: Document content looks like HTML 4.01 Strict
 Info: No system identifier in emitted doctype
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 The table summary attribute should be used to describe
 the table structure. It is very helpful for people using
@@ -19,7 +19,11 @@ For further advice on how to make your pages accessible
 see http://www.w3.org/WAI/GL.
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1316307.txt
+++ b/testbase/msg_1316307.txt
@@ -5,11 +5,15 @@ line 13 column 1 - Warning: trimming empty <center>
 Info: Doctype given is "-//W3C//DTD HTML 4.0 Transitional//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1326520.txt
+++ b/testbase/msg_1326520.txt
@@ -5,11 +5,15 @@ line 12 column 7 - Warning: missing </center> before <td>
 line 10 column 5 - Warning: The summary attribute on the <table> element is obsolete in HTML5
 line 12 column 7 - Warning: trimming empty <center>
 Info: Document content looks like HTML5
-5 warnings, 0 errors were found!
+Tidy found 5 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1331849.txt
+++ b/testbase/msg_1331849.txt
@@ -6,7 +6,7 @@ line 29 column 1 - Warning: <table> lacks "summary" attribute
 Info: Doctype given is "-//W3C//DTD HTML 4.0 Transitional//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 The table summary attribute should be used to describe
 the table structure. It is very helpful for people using
@@ -19,7 +19,11 @@ For further advice on how to make your pages accessible
 see http://www.w3.org/WAI/GL.
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1333579.txt
+++ b/testbase/msg_1333579.txt
@@ -7,11 +7,15 @@ line 5 column 1 - Warning: <div> isn't allowed in <tr> elements
 line 4 column 1 - Info: <tr> previously mentioned
 line 4 column 1 - Warning: missing </table> before </body>
 Info: Document content looks like HTML5
-6 warnings, 0 errors were found!
+Tidy found 6 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1359292.txt
+++ b/testbase/msg_1359292.txt
@@ -1,9 +1,13 @@
 Info: Document content looks like XHTML5
-3 warnings, 0 errors were found! Not all warnings/errors were shown.
+Tidy found 3 warnings and 0 errors! Not all warnings/errors were shown.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1398397.txt
+++ b/testbase/msg_1398397.txt
@@ -8,11 +8,15 @@ line 3 column 1 - Warning: trimming empty <ul>
 line 4 column 1 - Warning: trimming empty <tr>
 line 2 column 1 - Warning: trimming empty <table>
 Info: Document content looks like HTML5
-8 warnings, 0 errors were found!
+Tidy found 8 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1407266.txt
+++ b/testbase/msg_1407266.txt
@@ -1,7 +1,7 @@
 Warning: replacing invalid character code 159
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like HTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 Character codes 128 to 159 (U+0080 to U+009F) are not allowed in HTML;
 even if they were, they would likely be unprintable control characters.
@@ -10,7 +10,11 @@ specified encoding and replaced that reference with the Unicode equivalent.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1408034.txt
+++ b/testbase/msg_1408034.txt
@@ -4,11 +4,15 @@ line 1 column 1 - Info: <head> previously mentioned
 line 1 column 1 - Warning: inserting implicit <body>
 line 1 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like HTML5
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1410061-1.txt
+++ b/testbase/msg_1410061-1.txt
@@ -13,7 +13,7 @@ line 11 column 1 - Warning: discarding unexpected </html>
 line 7 column 1 - Warning: missing </ul>
 line 6 column 30 - Warning: trimming empty <font>
 Info: Document content looks like HTML5
-13 warnings, 0 errors were found!
+Tidy found 13 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -22,7 +22,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1410061-2.txt
+++ b/testbase/msg_1410061-2.txt
@@ -5,7 +5,7 @@ line 9 column 5 - Warning: inserting implicit <font>
 line 7 column 30 - Warning: trimming empty <font>
 Info: Doctype given is "-//W3C//DTD HTML 3.2//EN"
 Info: Document content looks like HTML 3.2
-5 warnings, 0 errors were found!
+Tidy found 5 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -14,7 +14,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1410061.txt
+++ b/testbase/msg_1410061.txt
@@ -16,11 +16,15 @@ line 7 column 1 - Warning: discarding unexpected </body>
 line 8 column 1 - Warning: discarding unexpected </html>
 line 6 column 319 - Warning: missing </ul>
 Info: Document content looks like HTML5
-16 warnings, 0 errors were found!
+Tidy found 16 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1415137.txt
+++ b/testbase/msg_1415137.txt
@@ -3,11 +3,15 @@ line 4 column 1 - Warning: plain text not inside 'noframes' element
 line 2 column 1 - Warning: missing </noframes>
 line 1 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like HTML5
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1423252.txt
+++ b/testbase/msg_1423252.txt
@@ -15,7 +15,7 @@ line 11 column 1 - Warning: trimming empty <dt>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-13 warnings, 0 errors were found!
+Tidy found 13 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -24,7 +24,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1426419.txt
+++ b/testbase/msg_1426419.txt
@@ -6,11 +6,15 @@ line 10 column 15 - Warning: replacing unexpected i by </i>
 line 10 column 38 - Warning: inserting implicit <b>
 Info: Doctype given is "-//W3C//DTD XHTML 1.0 Transitional//EN"
 Info: Document content looks like XHTML 1.0 Strict
-6 warnings, 0 errors were found!
+Tidy found 6 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1436578.txt
+++ b/testbase/msg_1436578.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1445570.txt
+++ b/testbase/msg_1445570.txt
@@ -4,7 +4,7 @@ line 7 column 1 - Warning: <a> escaping malformed URI reference
 line 8 column 1 - Warning: <img> escaping malformed URI reference
 Info: Doctype given is "-//W3C//DTD HTML 3.2//EN"
 Info: Document content looks like HTML 3.2
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 URIs must be properly escaped, they must not contain unescaped
 characters below U+0021 including the space character and not
@@ -17,7 +17,11 @@ http://www.w3.org/International/O-URL-and-ident.html
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1452744.txt
+++ b/testbase/msg_1452744.txt
@@ -9,7 +9,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1503897.txt
+++ b/testbase/msg_1503897.txt
@@ -17,11 +17,15 @@ line 11 column 1 - Warning: discarding unexpected </pre>
 line 7 column 20 - Warning: missing </table> before </body>
 line 10 column 20 - Warning: trimming empty <tr>
 Info: Document content looks like HTML5
-14 warnings, 0 errors were found!
+Tidy found 14 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1586158.txt
+++ b/testbase/msg_1586158.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1590220-1.txt
+++ b/testbase/msg_1590220-1.txt
@@ -6,11 +6,15 @@ line 14 column 1 - Info: <table> previously mentioned
 line 18 column 1 - Warning: discarding unexpected </pre>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Strict
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1590220-2.txt
+++ b/testbase/msg_1590220-2.txt
@@ -5,11 +5,15 @@ line 9 column 1 - Info: <table> previously mentioned
 line 14 column 1 - Warning: discarding unexpected </pre>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Strict
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1603538-1.txt
+++ b/testbase/msg_1603538-1.txt
@@ -6,11 +6,15 @@ line 6 column 1 - Warning: missing <li>
 line 3 column 1 - Warning: missing </ul>
 line 2 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like XHTML5
-6 warnings, 0 errors were found!
+Tidy found 6 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1603538-2.txt
+++ b/testbase/msg_1603538-2.txt
@@ -6,11 +6,15 @@ line 10 column 19 - Warning: discarding unexpected </th>
 line 13 column 14 - Warning: discarding unexpected </th>
 line 2 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like HTML5
-7 warnings, 0 errors were found!
+Tidy found 7 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1610888-1.txt
+++ b/testbase/msg_1610888-1.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1610888-2.txt
+++ b/testbase/msg_1610888-2.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1632218.txt
+++ b/testbase/msg_1632218.txt
@@ -5,7 +5,7 @@ line 8 column 17 - Warning: unescaped & or unknown entity "&#x128"
 line 9 column 17 - Warning: unescaped & or unknown entity "&#X128"
 line 7 column 1 - Warning: <a> escaping malformed URI reference
 Info: Document content looks like HTML5
-6 warnings, 0 errors were found!
+Tidy found 6 warnings and 0 errors!
 
 Character codes 128 to 159 (U+0080 to U+009F) are not allowed in HTML;
 even if they were, they would likely be unprintable control characters.
@@ -23,7 +23,11 @@ http://www.w3.org/International/O-URL-and-ident.html
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1632470.txt
+++ b/testbase/msg_1632470.txt
@@ -6,11 +6,15 @@ line 5 column 1 - Warning: </head> isn't allowed in <body> elements
 line 3 column 1 - Info: <body> previously mentioned
 line 6 column 1 - Warning: discarding unexpected <body>
 Info: Document content looks like HTML5
-5 warnings, 0 errors were found!
+Tidy found 5 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1638062.txt
+++ b/testbase/msg_1638062.txt
@@ -3,11 +3,15 @@ line 8 column 19 - Warning: <b> is probably intended as </b>
 Info: Doctype given is "-//W3C//DTD HTML 4.01 Transitional//EN"
 Info: Document content looks like HTML 4.01 Strict
 Info: No system identifier in emitted doctype
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1674502.txt
+++ b/testbase/msg_1674502.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 7 column 1 - Warning: discarding unexpected XML declaration
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1707836.txt
+++ b/testbase/msg_1707836.txt
@@ -11,11 +11,15 @@ line 7 column 9 - Warning: trimming empty <li>
 line 9 column 9 - Warning: trimming empty <li>
 line 5 column 1 - Warning: trimming empty <ol>
 Info: Document content looks like HTML5
-12 warnings, 0 errors were found!
+Tidy found 12 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1715153.txt
+++ b/testbase/msg_1715153.txt
@@ -10,11 +10,15 @@ line 1 column 1 - Warning: <embed> proprietary attribute "lign"
 line 1 column 1 - Warning: <embed> proprietary attribute "allowscriptaccess"
 line 1 column 1 - Warning: <embed> proprietary attribute "pluginspage"
 Info: Document content looks like HTML5
-11 warnings, 0 errors were found!
+Tidy found 11 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1720953.txt
+++ b/testbase/msg_1720953.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1773932.txt
+++ b/testbase/msg_1773932.txt
@@ -13,7 +13,7 @@ line 7 column 1 - Warning: trimming empty <font>
 line 9 column 6 - Warning: trimming empty <font>
 line 10 column 6 - Warning: trimming empty <font>
 Info: Document content looks like HTML5
-14 warnings, 0 errors were found!
+Tidy found 14 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -22,7 +22,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1986717-1.txt
+++ b/testbase/msg_1986717-1.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1986717-2.txt
+++ b/testbase/msg_1986717-2.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_1986717-3.txt
+++ b/testbase/msg_1986717-3.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_2046048.txt
+++ b/testbase/msg_2046048.txt
@@ -29,7 +29,7 @@ line 12 column 1 - Warning: trimming empty <caption>
 line 12 column 1 - Warning: trimming empty <table>
 Info: Doctype given is "-//W3C//DTD XHTML 1.0 Transitional//EN"
 Info: Document content looks like XHTML 1.0 Strict
-17 warnings, 4 errors were found!
+Tidy found 17 warnings and 4 errors!
 
 This document has errors that must be fixed before
 using HTML Tidy to generate a tidied up version.
@@ -38,7 +38,11 @@ For further advice on how to make your pages accessible
 see http://www.w3.org/WAI/GL and http://www.html-tidy.org/accessibility/.
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_2085175.txt
+++ b/testbase/msg_2085175.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_2359929.txt
+++ b/testbase/msg_2359929.txt
@@ -2,11 +2,15 @@ line 8 column 7 - Warning: <a> URI reference contains backslash. Typo?
 Info: Doctype given is "-//W3C//DTD HTML 4.01 Transitional//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_2705873-1.txt
+++ b/testbase/msg_2705873-1.txt
@@ -9,7 +9,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_2705873-2.txt
+++ b/testbase/msg_2705873-2.txt
@@ -8,7 +8,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_2709860.txt
+++ b/testbase/msg_2709860.txt
@@ -24,7 +24,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_426885.txt
+++ b/testbase/msg_426885.txt
@@ -17,7 +17,7 @@ line 8 column 41 - Warning: trimming empty <dt>
 line 9 column 27 - Warning: trimming empty <dl>
 line 12 column 41 - Warning: trimming empty <dt>
 Info: Document content looks like HTML5
-15 warnings, 0 errors were found!
+Tidy found 15 warnings and 0 errors!
 
 The alt attribute should be used to give a short description
 of an image; longer descriptions should be given with the
@@ -28,7 +28,11 @@ For further advice on how to make your pages accessible
 see http://www.w3.org/WAI/GL.
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427633.txt
+++ b/testbase/msg_427633.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427662.txt
+++ b/testbase/msg_427662.txt
@@ -3,7 +3,7 @@ line 7 column 1 - Warning: <a> isn't allowed in <table> elements
 line 6 column 1 - Info: <table> previously mentioned
 line 6 column 1 - Warning: The summary attribute on the <table> element is obsolete in HTML5
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -12,7 +12,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427664.txt
+++ b/testbase/msg_427664.txt
@@ -5,11 +5,15 @@ line 5 column 1 - Warning: <body> unexpected or duplicate quote mark
 line 5 column 1 - Warning: <body> attribute "width" has invalid value "align="""
 line 5 column 1 - Warning: <body> proprietary attribute "width"
 Info: Document content looks like HTML5
-6 warnings, 0 errors were found!
+Tidy found 6 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427671.txt
+++ b/testbase/msg_427671.txt
@@ -8,11 +8,15 @@ line 10 column 28 - Warning: discarding unexpected </optgroup>
 line 11 column 5 - Warning: discarding unexpected <option>
 line 11 column 24 - Warning: discarding unexpected </option>
 Info: Document content looks like HTML5
-9 warnings, 0 errors were found!
+Tidy found 9 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427672.txt
+++ b/testbase/msg_427672.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 5 column 1 - Warning: <body> attribute name "￿￿1/2" (value="xx") is invalid
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427675.txt
+++ b/testbase/msg_427675.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 8 column 1 - Warning: discarding unexpected <frame>
 line 10 column 1 - Warning: missing </noframes>
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427676.txt
+++ b/testbase/msg_427676.txt
@@ -6,14 +6,18 @@ line 6 column 14 - Warning: discarding unexpected <spanstyle>
 line 6 column 44 - Warning: discarding unexpected </span>
 line 6 column 52 - Warning: <a> unexpected or duplicate quote mark
 Info: Document content looks like HTML5
-6 warnings, 1 error were found!
+Tidy found 6 warnings and 1 error!
 
 This document has errors that must be fixed before
 using HTML Tidy to generate a tidied up version.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427677.txt
+++ b/testbase/msg_427677.txt
@@ -1,10 +1,14 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like HTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427810.txt
+++ b/testbase/msg_427810.txt
@@ -1,7 +1,7 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 8 column 1 - Warning: <blink> is not approved by W3C
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 You are recommended to use CSS to control line wrapping.
 Use "white-space: nowrap" to inhibit wrapping in place
@@ -9,7 +9,11 @@ of inserting <NOBR>...</NOBR> into the markup.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427811.txt
+++ b/testbase/msg_427811.txt
@@ -4,11 +4,15 @@ line 11 column 3 - Warning: discarding unexpected <body>
 line 13 column 3 - Warning: <frame> isn't allowed in <body> elements
 line 10 column 1 - Info: <body> previously mentioned
 Info: Document content looks like HTML5
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427813.txt
+++ b/testbase/msg_427813.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 5 column 1 - Warning: <body> attribute with missing trailing quote mark
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427816.txt
+++ b/testbase/msg_427816.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 6 column 1 - Warning: <a> unexpected or duplicate quote mark
 line 6 column 1 - Warning: <a> unexpected or duplicate quote mark
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427818.txt
+++ b/testbase/msg_427818.txt
@@ -3,7 +3,7 @@ line 7 column 1 - Warning: <a> attribute with missing trailing quote mark
 line 7 column 1 - Warning: <a> escaping malformed URI reference
 Info: Doctype given is "-//W3C//DTD HTML 3.2//EN"
 Info: Document content looks like HTML 3.2
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 URIs must be properly escaped, they must not contain unescaped
 characters below U+0021 including the space character and not
@@ -16,7 +16,11 @@ http://www.w3.org/International/O-URL-and-ident.html
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427819.txt
+++ b/testbase/msg_427819.txt
@@ -4,11 +4,15 @@ line 8 column 46 - Warning: discarding unexpected </font>
 line 12 column 25 - Warning: discarding unexpected <font>
 line 12 column 45 - Warning: discarding unexpected </font>
 Info: Document content looks like HTML5
-5 warnings, 0 errors were found!
+Tidy found 5 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427820.txt
+++ b/testbase/msg_427820.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 6 column 10 - Warning: The summary attribute on the <table> element is obsolete in HTML5
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427821.txt
+++ b/testbase/msg_427821.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427822.txt
+++ b/testbase/msg_427822.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 7 column 5 - Warning: missing </i> before </dd>
 line 7 column 16 - Warning: discarding unexpected </i>
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427823.txt
+++ b/testbase/msg_427823.txt
@@ -6,11 +6,15 @@ line 18 column 1 - Warning: plain text not inside 'noframes' element
 line 7 column 1 - Warning: content occurs after end of body
 line 7 column 1 - Warning: missing </noframes>
 Info: Document content looks like HTML5
-7 warnings, 0 errors were found!
+Tidy found 7 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427825.txt
+++ b/testbase/msg_427825.txt
@@ -1,11 +1,15 @@
 line 2 column 1 - Warning: missing <!DOCTYPE> declaration
 line 7 column 11 - Warning: <lm:xcode> is not approved by W3C
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427826.txt
+++ b/testbase/msg_427826.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427827.txt
+++ b/testbase/msg_427827.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 6 column 1 - Warning: missing </a> before <a>
 line 7 column 6 - Warning: discarding unexpected </a>
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427830.txt
+++ b/testbase/msg_427830.txt
@@ -1,10 +1,14 @@
 line 2 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like XHTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427833.txt
+++ b/testbase/msg_427833.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427834.txt
+++ b/testbase/msg_427834.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427835.txt
+++ b/testbase/msg_427835.txt
@@ -1,10 +1,14 @@
 line 2 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like XHTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427836.txt
+++ b/testbase/msg_427836.txt
@@ -5,7 +5,7 @@ line 2 column 1 - Warning: inserting missing 'title' element
 line 3 column 17 - Warning: <img> escaping malformed URI reference
 line 3 column 17 - Warning: <img> lacks "alt" attribute
 Info: Document content looks like HTML5
-6 warnings, 0 errors were found!
+Tidy found 6 warnings and 0 errors!
 
 URIs must be properly escaped, they must not contain unescaped
 characters below U+0021 including the space character and not
@@ -25,7 +25,11 @@ For further advice on how to make your pages accessible
 see http://www.w3.org/WAI/GL.
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427837.txt
+++ b/testbase/msg_427837.txt
@@ -2,7 +2,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427838.txt
+++ b/testbase/msg_427838.txt
@@ -8,11 +8,15 @@ line 10 column 1 - Warning: trimming empty <p>
 Info: Doctype given is "-//W3C//DTD HTML 4.0 Transitional//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-7 warnings, 0 errors were found!
+Tidy found 7 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427839.txt
+++ b/testbase/msg_427839.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427840.txt
+++ b/testbase/msg_427840.txt
@@ -5,11 +5,15 @@ line 5 column 4 - Warning: inserting implicit <span>
 line 6 column 1 - Warning: discarding unexpected </span>
 line 4 column 1 - Warning: trimming empty <span>
 Info: Document content looks like HTML5
-6 warnings, 0 errors were found!
+Tidy found 6 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427841.txt
+++ b/testbase/msg_427841.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 24 column 1 - Warning: missing <li>
 line 22 column 1 - Warning: missing </ul>
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427845.txt
+++ b/testbase/msg_427845.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_427846.txt
+++ b/testbase/msg_427846.txt
@@ -4,7 +4,7 @@ line 8 column 1 - Warning: inserting implicit <font>
 line 10 column 1 - Warning: inserting implicit <font>
 line 6 column 1 - Warning: trimming empty <font>
 Info: Document content looks like HTML5
-5 warnings, 0 errors were found!
+Tidy found 5 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -13,7 +13,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_431716.txt
+++ b/testbase/msg_431716.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_431721.txt
+++ b/testbase/msg_431721.txt
@@ -12,11 +12,15 @@ line 177 column 1 - Warning: replacing unexpected <p> by <li>
 line 181 column 1 - Warning: replacing unexpected <p> by <li>
 line 185 column 1 - Warning: replacing unexpected <p> by <li>
 Info: Document content looks like HTML5
-13 warnings, 0 errors were found!
+Tidy found 13 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_431731.txt
+++ b/testbase/msg_431731.txt
@@ -1,6 +1,6 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like HTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -9,7 +9,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_431736.txt
+++ b/testbase/msg_431736.txt
@@ -1,10 +1,14 @@
 line 2 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like XHTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_431739.txt
+++ b/testbase/msg_431739.txt
@@ -2,7 +2,7 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 6 column 1 - Warning: missing </font> before <hr>
 line 8 column 1 - Warning: inserting implicit <font>
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -11,7 +11,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_431874.txt
+++ b/testbase/msg_431874.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 4 column 1 - Warning: missing </a> before <a>
 line 4 column 74 - Warning: discarding unexpected </a>
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_431889.txt
+++ b/testbase/msg_431889.txt
@@ -1,11 +1,15 @@
 line 35 column 4 - Warning: <img> inserting "alt" attribute using value "Alternate"
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Strict
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_431898.txt
+++ b/testbase/msg_431898.txt
@@ -1,11 +1,15 @@
 line 11 column 13 - Warning: unescaped & or unknown entity "&myURI"
 Info: Doctype given is "-//W3C//DTD XHTML 1.0 Strict//EN"
 Info: Document content looks like XHTML 1.0 Strict
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_431958.txt
+++ b/testbase/msg_431958.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_431964.txt
+++ b/testbase/msg_431964.txt
@@ -2,11 +2,15 @@ line 7 column 1 - Warning: <table> attribute "height" lacks value
 line 7 column 1 - Warning: <table> proprietary attribute "height"
 Info: Doctype given is "-//W3C//DTD HTML 4.01 Transitional//EN"
 Info: Document content looks like HTML Proprietary
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_432677.txt
+++ b/testbase/msg_432677.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433012.txt
+++ b/testbase/msg_433012.txt
@@ -606,7 +606,7 @@ line 300 column 2 - Warning: <a> escaping malformed URI reference
 line 695 column 2 - Warning: <a> escaping malformed URI reference
 line 698 column 2 - Warning: <a> escaping malformed URI reference
 Info: Document content looks like HTML5
-607 warnings, 0 errors were found!
+Tidy found 607 warnings and 0 errors!
 
 URIs must be properly escaped, they must not contain unescaped
 characters below U+0021 including the space character and not
@@ -619,7 +619,11 @@ http://www.w3.org/International/O-URL-and-ident.html
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433021.txt
+++ b/testbase/msg_433021.txt
@@ -6,11 +6,15 @@ line 11 column 1 - Warning: <td> attribute "valign" has invalid value "fuzzle"
 line 13 column 1 - Warning: <td> attribute "align" has invalid value "fuzzle"
 line 13 column 1 - Warning: <td> attribute "valign" has invalid value "fuzzle"
 Info: Document content looks like HTML5
-7 warnings, 0 errors were found!
+Tidy found 7 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433040.txt
+++ b/testbase/msg_433040.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433359.txt
+++ b/testbase/msg_433359.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433360.txt
+++ b/testbase/msg_433360.txt
@@ -1,7 +1,7 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 6 column 1 - Warning: <font> missing '>' for end of tag
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -10,7 +10,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433604.txt
+++ b/testbase/msg_433604.txt
@@ -2,7 +2,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433607.txt
+++ b/testbase/msg_433607.txt
@@ -2,7 +2,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433656.txt
+++ b/testbase/msg_433656.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433666.txt
+++ b/testbase/msg_433666.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 4 column 1 - Warning: <table> dropping value "right" for repeated attribute "align"
 line 4 column 1 - Warning: The summary attribute on the <table> element is obsolete in HTML5
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433672.txt
+++ b/testbase/msg_433672.txt
@@ -1,10 +1,14 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like HTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_433856.txt
+++ b/testbase/msg_433856.txt
@@ -17,7 +17,7 @@ line 10 column 4 - Warning: trimming empty <u>
 line 10 column 1 - Warning: trimming empty <b>
 line 11 column 16 - Warning: trimming empty <font>
 Info: Document content looks like HTML5
-18 warnings, 0 errors were found!
+Tidy found 18 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -26,7 +26,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_434047.txt
+++ b/testbase/msg_434047.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_434100.txt
+++ b/testbase/msg_434100.txt
@@ -1,12 +1,16 @@
 line 13 column 1 - Error: unexpected </head> in <link>
-0 warnings, 1 error were found!
+Tidy found 0 warnings and 1 error!
 
 This document has errors that must be fixed before
 using HTML Tidy to generate a tidied up version.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_434940.txt
+++ b/testbase/msg_434940.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_435903.txt
+++ b/testbase/msg_435903.txt
@@ -3,11 +3,15 @@ line 10 column 9 - Warning: <script> isn't allowed in <tr> elements
 line 9 column 7 - Info: <tr> previously mentioned
 line 9 column 7 - Warning: trimming empty <tr>
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_435917.txt
+++ b/testbase/msg_435917.txt
@@ -6,11 +6,15 @@ line 8 column 1 - Warning: missing </form>
 Info: Doctype given is "-//W3C//DTD HTML 4.01 Transitional//EN"
 Info: Document content looks like HTML 4.01 Transitional
 Info: No system identifier in emitted doctype
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_435919.txt
+++ b/testbase/msg_435919.txt
@@ -1,10 +1,14 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like HTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_435920.txt
+++ b/testbase/msg_435920.txt
@@ -1,7 +1,7 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 7 column 1 - Warning: The summary attribute on the <table> element is obsolete in HTML5
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -10,7 +10,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_435922.txt
+++ b/testbase/msg_435922.txt
@@ -4,11 +4,15 @@ line 5 column 1 - Info: <body> previously mentioned
 line 6 column 3 - Warning: inserting implicit <form>
 line 6 column 3 - Warning: missing </form>
 Info: Document content looks like HTML5
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_435923.txt
+++ b/testbase/msg_435923.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_437468.txt
+++ b/testbase/msg_437468.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_438650.txt
+++ b/testbase/msg_438650.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 6 column 1 - Warning: <a> discarding newline in URI reference
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_438658.txt
+++ b/testbase/msg_438658.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 3 column 1 - Warning: <title> is probably intended as </title>
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_438954.txt
+++ b/testbase/msg_438954.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_438956.txt
+++ b/testbase/msg_438956.txt
@@ -4,11 +4,15 @@ line 2 column 1 - Info: <head> previously mentioned
 line 4 column 1 - Warning: inserting implicit <body>
 line 5 column 1 - Warning: discarding unexpected <body>
 Info: Document content looks like HTML5
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_441508.txt
+++ b/testbase/msg_441508.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 4 column 1 - Warning: <table> dropping value "right" for repeated attribute "align"
 line 7 column 1 - Warning: missing <tr>
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_441568.txt
+++ b/testbase/msg_441568.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_443362.txt
+++ b/testbase/msg_443362.txt
@@ -1,11 +1,15 @@
 line 26 column 11 - Warning: discarding unexpected <!DOCTYPE>
 Info: Doctype given is "-//W3C//DTD XHTML 1.0 Strict//EN"
 Info: Document content looks like XHTML 1.0 Strict
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_443576.txt
+++ b/testbase/msg_443576.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 8 column 31 - Warning: '<' + '/' + letter not allowed here
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_443678.txt
+++ b/testbase/msg_443678.txt
@@ -1,12 +1,16 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 11 column 1 - Warning: missing </script>
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 You are recommended to use CSS to specify page and link colors
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_445074.txt
+++ b/testbase/msg_445074.txt
@@ -1,11 +1,15 @@
 line 8 column 1 - Warning: <form> attribute value "POST" must be lower case for XHTML
 Info: Doctype given is "-//W3C//DTD XHTML 1.0 Strict//EN"
 Info: Document content looks like XHTML 1.0 Strict
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_445394.txt
+++ b/testbase/msg_445394.txt
@@ -2,7 +2,7 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 6 column 1 - Warning: <a> attribute with missing trailing quote mark
 line 6 column 1 - Warning: <a> escaping malformed URI reference
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 URIs must be properly escaped, they must not contain unescaped
 characters below U+0021 including the space character and not
@@ -15,7 +15,11 @@ http://www.w3.org/International/O-URL-and-ident.html
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_445557.txt
+++ b/testbase/msg_445557.txt
@@ -10,7 +10,7 @@ line 16 column 5 - Warning: replacing invalid numeric character reference 150
 line 18 column 5 - Warning: replacing invalid numeric character reference 150
 line 20 column 5 - Warning: replacing invalid numeric character reference 150
 Info: Document content looks like HTML5
-11 warnings, 0 errors were found!
+Tidy found 11 warnings and 0 errors!
 
 Character codes 128 to 159 (U+0080 to U+009F) are not allowed in HTML;
 even if they were, they would likely be unprintable control characters.
@@ -24,7 +24,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_449348.txt
+++ b/testbase/msg_449348.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_470663.txt
+++ b/testbase/msg_470663.txt
@@ -3,11 +3,15 @@ line 1 column 1 - Warning: <html> proprietary attribute "xmlns:v"
 line 1 column 1 - Warning: <html> proprietary attribute "xmlns:o"
 line 1 column 1 - Warning: <html> proprietary attribute "xmlns:w"
 Info: Document content looks like HTML5
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_480406.txt
+++ b/testbase/msg_480406.txt
@@ -2,7 +2,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_480701.txt
+++ b/testbase/msg_480701.txt
@@ -2,7 +2,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_487204.txt
+++ b/testbase/msg_487204.txt
@@ -2,11 +2,15 @@ line 5 column 1 - Warning: inserting implicit <body>
 line 6 column 2 - Warning: missing <li>
 Info: Doctype given is "-//W3C//DTD HTML 4.01 Transitional//EN"
 Info: Document content looks like HTML 4.01 Strict
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_487283.txt
+++ b/testbase/msg_487283.txt
@@ -1,10 +1,14 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like HTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_500236.txt
+++ b/testbase/msg_500236.txt
@@ -1,9 +1,13 @@
 line 1 column 11 - Warning: adjacent hyphens within comment
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_501669.txt
+++ b/testbase/msg_501669.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_503436.txt
+++ b/testbase/msg_503436.txt
@@ -1,9 +1,13 @@
 line 6 column 3 - Warning: <img> dropping value "first" for repeated attribute "alt"
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_504206.txt
+++ b/testbase/msg_504206.txt
@@ -7,7 +7,7 @@ line 42 column 1 - Warning: trimming empty <p>
 line 138 column 1 - Warning: trimming empty <p>
 line 143 column 1 - Warning: trimming empty <p>
 Info: Document content looks like HTML5
-8 warnings, 0 errors were found!
+Tidy found 8 warnings and 0 errors!
 
 URIs must be properly escaped, they must not contain unescaped
 characters below U+0021 including the space character and not
@@ -20,7 +20,11 @@ http://www.w3.org/International/O-URL-and-ident.html
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_505770.txt
+++ b/testbase/msg_505770.txt
@@ -1,10 +1,14 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like HTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_511243.txt
+++ b/testbase/msg_511243.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_511679.txt
+++ b/testbase/msg_511679.txt
@@ -3,11 +3,15 @@ line 2 column 1 - Warning: inserting implicit <body>
 line 4 column 7 - Warning: missing </pre> before </td>
 line 2 column 1 - Warning: The summary attribute on the <table> element is obsolete in HTML5
 Info: Document content looks like HTML5
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_533233.txt
+++ b/testbase/msg_533233.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_540571.txt
+++ b/testbase/msg_540571.txt
@@ -10,7 +10,7 @@ line 10 column 23 - Warning: <span> proprietary attribute "color"
 line 6 column 1 - Warning: trimming empty <font>
 line 10 column 1 - Warning: trimming empty <span>
 Info: Document content looks like XHTML5
-11 warnings, 0 errors were found!
+Tidy found 11 warnings and 0 errors!
 
 You are recommended to use CSS to specify the font and
 properties such as its size and color. This will reduce
@@ -19,7 +19,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_545772.txt
+++ b/testbase/msg_545772.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_553468.txt
+++ b/testbase/msg_553468.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_566542.txt
+++ b/testbase/msg_566542.txt
@@ -26,11 +26,15 @@ line 7 column 1 - Warning: trimming empty <li>
 line 7 column 1 - Warning: trimming empty <ul>
 line 8 column 35 - Warning: trimming empty <p>
 Info: Document content looks like HTML5
-25 warnings, 0 errors were found!
+Tidy found 25 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_586562.txt
+++ b/testbase/msg_586562.txt
@@ -2,11 +2,15 @@ line 5 column 3 - Warning: discarding unexpected <!DOCTYPE>
 Info: Doctype given is "-//W3C//DTD HTML 4.0 Transitional//EN"
 Info: Document content looks like HTML 4.01 Strict
 Info: No system identifier in emitted doctype
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_588061.txt
+++ b/testbase/msg_588061.txt
@@ -97,7 +97,7 @@ line 168 column 131 - Warning: <a> cannot copy name attribute to id
 line 200 column 176 - Warning: <a> cannot copy name attribute to id
 line 248 column 94 - Warning: <a> cannot copy name attribute to id
 Info: Document content looks like HTML5
-96 warnings, 0 errors were found!
+Tidy found 96 warnings and 0 errors!
 
 URIs must be properly escaped, they must not contain unescaped
 characters below U+0021 including the space character and not
@@ -122,7 +122,11 @@ compared with using <FONT> elements.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_590716.txt
+++ b/testbase/msg_590716.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 799 column 17 - Warning: unescaped & or unknown entity "&foo"
 line 799 column 32 - Warning: unescaped & or unknown entity "&foo"
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_593705.txt
+++ b/testbase/msg_593705.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_609058.txt
+++ b/testbase/msg_609058.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_616744.txt
+++ b/testbase/msg_616744.txt
@@ -2,7 +2,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_620531.txt
+++ b/testbase/msg_620531.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 2 column 1 - Warning: inserting implicit <body>
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_629885.txt
+++ b/testbase/msg_629885.txt
@@ -1,10 +1,14 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like HTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_634889.txt
+++ b/testbase/msg_634889.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 7 column 3 - Warning: <o:p> is not approved by W3C
 Info: Document content looks like XHTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_640473.txt
+++ b/testbase/msg_640473.txt
@@ -5,11 +5,15 @@ line 3 column 32 - Warning: <zippo> is not approved by W3C
 line 5 column 1 - Warning: <zippo> is not approved by W3C
 line 6 column 1 - Warning: <baz> is not approved by W3C
 Info: Document content looks like HTML5
-6 warnings, 0 errors were found!
+Tidy found 6 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_640474.txt
+++ b/testbase/msg_640474.txt
@@ -2,7 +2,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_646946.txt
+++ b/testbase/msg_646946.txt
@@ -2,7 +2,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_647255.txt
+++ b/testbase/msg_647255.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 1 column 1 - Warning: inserting implicit <body>
 line 1 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like XHTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_647900.txt
+++ b/testbase/msg_647900.txt
@@ -8,7 +8,7 @@ line 13 column 3 - Warning: The summary attribute on the <table> element is obso
 line 18 column 5 - Warning: The summary attribute on the <table> element is obsolete in HTML5
 line 26 column 5 - Warning: The summary attribute on the <table> element is obsolete in HTML5
 Info: Document content looks like HTML5
-7 warnings, 2 errors were found!
+Tidy found 7 warnings and 2 errors!
 
 You may need to move one or both of the <form> and </form>
 tags. HTML elements should be properly nested and form elements
@@ -19,7 +19,11 @@ table! Note that one form can't be nested inside another!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_649812.txt
+++ b/testbase/msg_649812.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_655338.txt
+++ b/testbase/msg_655338.txt
@@ -2,11 +2,15 @@ line 2 column 1 - Warning: removing whitespace preceding XML Declaration
 line 7 column 1 - Warning: inserting implicit <body>
 Info: Doctype given is "-//W3C//DTD HTML 4.0 Transitional//EN"
 Info: Document content looks like XHTML 1.0 Strict
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_656889.txt
+++ b/testbase/msg_656889.txt
@@ -1,10 +1,14 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like HTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_658230.txt
+++ b/testbase/msg_658230.txt
@@ -3,11 +3,15 @@ line 1 column 1 - Warning: inserting implicit <body>
 line 1 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like HTML5
 Info: No system identifier in emitted doctype
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_660397.txt
+++ b/testbase/msg_660397.txt
@@ -1,11 +1,15 @@
 line 3 column 1 - Warning: inserting missing 'title' element
 Info: Doctype given is "-//W3C//DTD HTML 4.0 Transitional//EN"
 Info: Document content looks like XHTML 1.0 Transitional
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_661606.txt
+++ b/testbase/msg_661606.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_671087.txt
+++ b/testbase/msg_671087.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_676156.txt
+++ b/testbase/msg_676156.txt
@@ -5,11 +5,15 @@ line 1 column 1 - Warning: inserting implicit <body>
 line 3 column 22 - Warning: adjacent hyphens within comment
 line 1 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like HTML5
-5 warnings, 0 errors were found!
+Tidy found 5 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_676205.txt
+++ b/testbase/msg_676205.txt
@@ -6,7 +6,7 @@ line 11 column 1 - Warning: <img> escaping malformed URI reference
 line 11 column 1 - Warning: <img> lacks "alt" attribute
 Info: Doctype given is "-//W3C//DTD XHTML 1.0 Transitional//EN"
 Info: Document content looks like XHTML 1.0 Transitional
-6 warnings, 0 errors were found!
+Tidy found 6 warnings and 0 errors!
 
 URIs must be properly escaped, they must not contain unescaped
 characters below U+0021 including the space character and not
@@ -26,7 +26,11 @@ For further advice on how to make your pages accessible
 see http://www.w3.org/WAI/GL.
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_678268.txt
+++ b/testbase/msg_678268.txt
@@ -6,7 +6,7 @@ line 1 column 1 - Warning: <html> proprietary attribute "xmlns:msxsl"
 line 1 column 1 - Warning: <html> proprietary attribute "xmlns:user"
 line 12 column 1 - Warning: <table> lacks "summary" attribute
 Info: Document content looks like XHTML5
-7 warnings, 0 errors were found!
+Tidy found 7 warnings and 0 errors!
 
 The table summary attribute should be used to describe
 the table structure. It is very helpful for people using
@@ -19,7 +19,11 @@ For further advice on how to make your pages accessible
 see http://www.w3.org/WAI/GL.
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_688746.txt
+++ b/testbase/msg_688746.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 4 column 13 - Warning: adjacent hyphens within comment
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_695408.txt
+++ b/testbase/msg_695408.txt
@@ -3,11 +3,15 @@ line 8 column 11 - Warning: <span> proprietary attribute "datafld"
 line 9 column 11 - Warning: <span> proprietary attribute "datafld"
 line 10 column 11 - Warning: <span> proprietary attribute "datafld"
 Info: Document content looks like HTML5
-4 warnings, 0 errors were found!
+Tidy found 4 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_696799.txt
+++ b/testbase/msg_696799.txt
@@ -1,10 +1,14 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 Info: Document content looks like HTML5
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_706260.txt
+++ b/testbase/msg_706260.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_765852.txt
+++ b/testbase/msg_765852.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 3 column 1 - Warning: inserting implicit <body>
 line 3 column 29 - Warning: trimming empty <b>
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_795643-1.txt
+++ b/testbase/msg_795643-1.txt
@@ -2,11 +2,15 @@ line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 1 column 1 - Warning: inserting implicit <body>
 line 1 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like HTML5
-3 warnings, 0 errors were found!
+Tidy found 3 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_795643-2.txt
+++ b/testbase/msg_795643-2.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 1 column 1 - Warning: inserting missing 'title' element
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_836462-2.txt
+++ b/testbase/msg_836462-2.txt
@@ -2,11 +2,15 @@ line 13 column 3 - Warning: missing <li>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Strict
 Info: No system identifier in emitted doctype
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_836462-3.txt
+++ b/testbase/msg_836462-3.txt
@@ -1,11 +1,15 @@
 line 6 column 1 - Warning: missing <li>
 Info: Doctype given is "-//W3C//DTD XHTML 1.0 Transitional//EN"
 Info: Document content looks like XHTML 1.0 Strict
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_836462.txt
+++ b/testbase/msg_836462.txt
@@ -2,11 +2,15 @@ line 13 column 3 - Warning: missing <li>
 Info: Doctype given is "-//W3C//DTD HTML 4.01//EN"
 Info: Document content looks like HTML 4.01 Strict
 Info: No system identifier in emitted doctype
-1 warning, 0 errors were found!
+Tidy found 1 warning and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_837023.txt
+++ b/testbase/msg_837023.txt
@@ -1,11 +1,15 @@
 line 1 column 1 - Warning: missing <!DOCTYPE> declaration
 line 9 column 7 - Warning: discarding malformed <!DOCTYPE>
 Info: Document content looks like HTML5
-2 warnings, 0 errors were found!
+Tidy found 2 warnings and 0 errors!
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_978947.txt
+++ b/testbase/msg_978947.txt
@@ -5,7 +5,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md

--- a/testbase/msg_996484.txt
+++ b/testbase/msg_996484.txt
@@ -4,7 +4,11 @@ No warnings or errors were found.
 
 About HTML Tidy: https://github.com/htacg/tidy-html5
 Bug reports and comments: https://github.com/htacg/tidy-html5/issues
-Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/
+Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/
 Latest HTML specification: http://dev.w3.org/html5/spec-author-view/
 Validate your HTML documents: http://validator.w3.org/nu/
 Lobby your company to join the W3C: http://www.w3.org/Consortium
+
+Do you speak a language other than English, or a different variant of 
+English? Consider helping us to localize HTML Tidy. For details please see 
+https://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md


### PR DESCRIPTION
This takes the strings introduced by tidy-html5@d505869910b019731c160fe3b3c944fb5026f3d6 into account.  It was auto-generated using `sed`:

```sh
sed -E -i 's/([0-9]+) (warnings?), ([0-9]+) (errors?) were found/Tidy found \1 \2 and \3 \4/' testbase/msg_*.txt
sed -E -i 's!Or send questions and comments to: https://lists.w3.org/Archives/Public/public-htacg/!Official mailing list: https://lists.w3.org/Archives/Public/public-htacg/!g' testbase/msg_*.txt
sed -E -i $'/Lobby your company to join the W3C/{a\\\n\\\nDo you speak a language other than English, or a different variant of \\\nEnglish? Consider helping us to localize HTML Tidy. For details please see \\\nhttps://github.com/htacg/tidy-html5/blob/master/README/LOCALIZE.md\n}' testbase/msg_*.txt
```

This is part of the fix needed for #5, but there are other differences which are not due to the string changes.