### PR TITLE
Make the bash scripts path-agnostic

### DIFF
--- a/tools-sh/_environment.sh
+++ b/tools-sh/_environment.sh
@@ -21,8 +21,8 @@ fi
 # Change these if necessary:
 #############################################################################
 
-# Relative path from this script to the top-level tidy-html5-tests directory.
-project_root_dir=".."
+# Absolute path of the top-level tidy-html5-tests directory.
+project_root_dir="$(readlink -e $(dirname $0)/..)"
 
 # These are all relative from the project_root_dir directory.
 cases_base_dir="cases"
@@ -72,7 +72,7 @@ set_environment()
     # cd "${cwd}"
     
     # *Only* set TY_CASES_SETNAME if it's not already set!
-    if [ -z "$TY_CASES_SETNAME" ]; then
+    if [ -z "${TY_CASES_SETNAME}" ]; then
         export TY_CASES_SETNAME="${cases_setname}"   
     fi
     
@@ -92,20 +92,20 @@ set_environment()
 
 report_environment()
 {
-    echo "TY_PROJECT_ROOT_DIR = $TY_PROJECT_ROOT_DIR"
-    echo "  TY_CASES_BASE_DIR = $TY_CASES_BASE_DIR"
-    echo "       TY_CASES_DIR = $TY_CASES_DIR"
-    echo "     TY_EXPECTS_DIR = $TY_EXPECTS_DIR"
-    echo "    TY_EXPECTS_FILE = $TY_EXPECTS_FILE"
-    echo "  TY_CONFIG_DEFAULT = $TY_CONFIG_DEFAULT"
-    echo "    TY_VERSION_FILE = $TY_VERSION_FILE"
-    echo "TY_RESULTS_BASE_DIR = $TY_RESULTS_BASE_DIR"
-    echo "     TY_RESULTS_DIR = $TY_RESULTS_DIR"
-    echo "    TY_RESULTS_FILE = $TY_RESULTS_FILE"
-    echo "         TY_TMP_DIR = $TY_TMP_DIR"
-    echo "        TY_TMP_FILE = $TY_TMP_FILE"
-    echo "       TY_TIDY_PATH = $TY_TIDY_PATH"
-    echo "   TY_CASES_SETNAME = $TY_CASES_SETNAME"
+    echo "TY_PROJECT_ROOT_DIR = ${TY_PROJECT_ROOT_DIR}"
+    echo "  TY_CASES_BASE_DIR = ${TY_CASES_BASE_DIR}"
+    echo "       TY_CASES_DIR = ${TY_CASES_DIR}"
+    echo "     TY_EXPECTS_DIR = ${TY_EXPECTS_DIR}"
+    echo "    TY_EXPECTS_FILE = ${TY_EXPECTS_FILE}"
+    echo "  TY_CONFIG_DEFAULT = ${TY_CONFIG_DEFAULT}"
+    echo "    TY_VERSION_FILE = ${TY_VERSION_FILE}"
+    echo "TY_RESULTS_BASE_DIR = ${TY_RESULTS_BASE_DIR}"
+    echo "     TY_RESULTS_DIR = ${TY_RESULTS_DIR}"
+    echo "    TY_RESULTS_FILE = ${TY_RESULTS_FILE}"
+    echo "         TY_TMP_DIR = ${TY_TMP_DIR}"
+    echo "        TY_TMP_FILE = ${TY_TMP_FILE}"
+    echo "       TY_TIDY_PATH = ${TY_TIDY_PATH}"
+    echo "   TY_CASES_SETNAME = ${TY_CASES_SETNAME}"
 }
 
 report_testbase_version()
@@ -119,10 +119,10 @@ report_tidy_version()
     local version=$(${TY_TIDY_PATH} -v)
     if [ ! "$?" = "0" ]; then
         echo ""
-        echo "$BN: ${TY_TIDY_PATH}"
-        echo "$BN: Tidy was unable to run '${TY_TIDY_PATH} -v' successfully."
+        echo "${BN}: ${TY_TIDY_PATH}"
+        echo "${BN}: Tidy was unable to run '${TY_TIDY_PATH} -v' successfully."
         echo ""
-        ERROR_COUNT=$(($ERROR_COUNT + 1))
+        ERROR_COUNT=$((${ERROR_COUNT} + 1))
         return 1
     fi    
     echo $version
@@ -137,10 +137,10 @@ test_case_file()
 {
     if [ ! -f "$1" ]; then
         echo ""
-        echo "$BN: Case file: $1"
-        echo "$BN: This case file was not found. Is the number correct?"
+        echo "${BN}: Case file: $1"
+        echo "${BN}: This case file was not found. Is the number correct?"
         echo ""
-        ERROR_COUNT=$(($ERROR_COUNT + 1))
+        ERROR_COUNT=$((${ERROR_COUNT} + 1))
         return 1
     fi
 }
@@ -149,10 +149,10 @@ test_case_config()
 {
     if [ ! -f "$1" ]; then
         echo ""
-        echo "$BN: Config file: $1"
-        echo "$BN: This configuration file was not found."
+        echo "${BN}: Config file: $1"
+        echo "${BN}: This configuration file was not found."
         echo ""
-        ERROR_COUNT=$(($ERROR_COUNT + 1))
+        ERROR_COUNT=$((${ERROR_COUNT} + 1))
         return 1
     fi
 }
@@ -162,9 +162,9 @@ test_file_general()
 {
     if [ ! -f "$1" ]; then
         echo ""
-        echo "$BN: $1"
-        echo "$BN: This file is needed but was not found."
-        ERROR_COUNT=$(($ERROR_COUNT + 1))
+        echo "${BN}: $1"
+        echo "${BN}: This file is needed but was not found."
+        ERROR_COUNT=$((${ERROR_COUNT} + 1))
         return 1
     fi
 }
@@ -174,10 +174,10 @@ test_file_expects()
 {
     if [ ! -f "$1" ]; then
         echo ""
-        echo "$BN: Expects file: $1"
-        echo "$BN: This file is needed for the compare, but this may not be a problem."
-        echo "$BN: Maybe there is no 'expects' file for test $1!"
-        ERROR_COUNT=$(($ERROR_COUNT + 1))
+        echo "${BN}: Expects file: $1"
+        echo "${BN}: This file is needed for the compare, but this may not be a problem."
+        echo "${BN}: Maybe there is no 'expects' file for test $1!"
+        ERROR_COUNT=$((${ERROR_COUNT} + 1))
         return 1
     fi
 }
@@ -187,11 +187,11 @@ test_file_output()
 {
     if [ ! -f "$1" ]; then
         echo ""
-        echo "$BN: Tidy output: $1"
-        echo "$BN: This file is needed for the compare. It is strange this it was not created."
-        echo "$BN: *** NEEDS CHECKING ***"
+        echo "${BN}: Tidy output: $1"
+        echo "${BN}: This file is needed for the compare. It is strange this it was not created."
+        echo "${BN}: *** NEEDS CHECKING ***"
         echo ""
-        ERROR_COUNT=$(($ERROR_COUNT + 1))
+        ERROR_COUNT=$((${ERROR_COUNT} + 1))
         return 1
     fi
 }
@@ -200,11 +200,11 @@ test_results_base_dir()
 {
     if [ ! -d "${TY_RESULTS_BASE_DIR}" ]; then
         echo ""
-        echo "$BN: ${TY_RESULTS_BASE_DIR}"
-        echo "$BN: This results directory was not found; it must be created yourself."
-        echo "$BN: This script does NOT create this directory."
+        echo "${BN}: ${TY_RESULTS_BASE_DIR}"
+        echo "${BN}: This results directory was not found; it must be created yourself."
+        echo "${BN}: This script does NOT create this directory."
         echo ""
-        ERROR_COUNT=$(($ERROR_COUNT + 1))
+        ERROR_COUNT=$((${ERROR_COUNT} + 1))
         return 1
     fi
 }
@@ -213,21 +213,21 @@ test_tidy_path()
 {
     if [ -z "${TY_TIDY_PATH+x}" ]; then
         echo ""
-        echo "$BN: TY_TIDY_PATH is not set"
-        echo "$BN: You must call this script with an argument pointing to an instance"
-        echo "$BN: of HTML Tidy, or set the TY_TIDY_PATH environment variable to"
-        echo "$BN: point to an instance of HTML Tidy."
+        echo "${BN}: TY_TIDY_PATH is not set"
+        echo "${BN}: You must call this script with an argument pointing to an instance"
+        echo "${BN}: of HTML Tidy, or set the TY_TIDY_PATH environment variable to"
+        echo "${BN}: point to an instance of HTML Tidy."
         echo ""
-        ERROR_COUNT=$(($ERROR_COUNT + 1))
+        ERROR_COUNT=$((${ERROR_COUNT} + 1))
         return 1
     fi
     
     if [ ! -x "${TY_TIDY_PATH}" ]; then
         echo ""
-        echo "$BN: ${TY_TIDY_PATH}"
-        echo "$BN: This instance of Tidy was not found. Is it on your path?"
+        echo "${BN}: ${TY_TIDY_PATH}"
+        echo "${BN}: This instance of Tidy was not found. Is it on your path?"
         echo ""
-        ERROR_COUNT=$(($ERROR_COUNT + 1))
+        ERROR_COUNT=$((${ERROR_COUNT} + 1))
         return 1
     fi
 }
@@ -241,4 +241,3 @@ test_tidy_path()
 BN="`basename $0`"
 ERROR_COUNT=0
 # eof
-

--- a/tools-sh/_envtest.sh
+++ b/tools-sh/_envtest.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-source _environment.sh
+DIR="$(readlink -e $(dirname $0))"
+source "${DIR}/_environment.sh"
 
 set_environment
 
@@ -14,4 +15,4 @@ test_results_base_dir
 
 version=$(report_tidy_version)
 
-echo $version
+echo "${version}"

--- a/tools-sh/cmp.sh
+++ b/tools-sh/cmp.sh
@@ -4,19 +4,20 @@
 # this can COMPARE the files ONE BY ONE
 #
 BN=`basename $0`
+DIR="$(readlink -e $(dirname $0))"
 
-TMPDIR1=$1
-TMPDIR2=$2
+TMPDIR1="$1"
+TMPDIR2="$2"
 OUTLOG="temp.diff"
 TMPDOP="-ua"
 
 usage()
 {
 	echo ""
-	echo "Usage: ./$BN directory1 directory2"
+	echo "Usage: ./${BN} directory1 directory2"
 	echo ""
-	echo "$BN: If you have the tidied HTML output from two version of 'tidy' then "
-	echo "$BN: this can COMPARE the output files ONE BY ONE, output to $OUTLOG"
+	echo "${BN}: If you have the tidied HTML output from two version of 'tidy' then "
+	echo "${BN}: this can COMPARE the output files ONE BY ONE, output to ${OUTLOG}"
 	echo ""
 }
 
@@ -25,21 +26,21 @@ d_now()
     date +%Y%m%d%H%M%S
 }
 
-if [ -z "$TMPDIR1" ] || [ -z "$TMPDIR2" ] || [ "$TMPDIR1" = "--help" ] || [ "$TMPDIR1" = "-h" ] || [ "$TMPDIR1" = "-?" ]; then
+if [ -z "${TMPDIR1}" ] || [ -z "${TMPDIR2}" ] || [ "${TMPDIR1}" = "--help" ] || [ "${TMPDIR1}" = "-h" ] || [ "${TMPDIR1}" = "-?" ]; then
 	usage
 	exit 1
 fi
 
 
-if [ ! -d "$TMPDIR1" ]; then
+if [ ! -d "${TMPDIR1}" ]; then
 	usage
-	echo "$BN: Can NOT locate directory 1 '$TMPDIR1'!"
+	echo "${BN}: Can NOT locate directory 1 '${TMPDIR1}'!"
 	exit 1
 fi
 
-if [ ! -d "$TMPDIR2" ]; then
+if [ ! -d "${TMPDIR2}" ]; then
 	usage
-	echo "$BN: Can NOT locate directory 2 '$TMPDIR2'!"
+	echo "${BN}: Can NOT locate directory 2 '${TMPDIR2}'!"
 	exit 1
 fi
 
@@ -56,54 +57,53 @@ DIFFFILES=""
 TMPMASK="*"
 # TMPMASK="*.html"
 
-for fil in $TMPDIR1/$TMPMASK; do
-	TMPCNT1=`expr $TMPCNT1 + 1`
+for fil in "${TMPDIR1}"/${TMPMASK}; do
+	TMPCNT1=`expr ${TMPCNT1} + 1`
 done
 
-for fil in $TMPDIR2/$TMPMASK; do
-	TMPCNT2=`expr $TMPCNT2 + 1`
+for fil in "${TMPDIR2}"/${TMPMASK}; do
+	TMPCNT2=`expr ${TMPCNT2} + 1`
 done
 
-echo "$BN: Found $TMPCNT1 files in $TMPDIR1"
-echo "$BN: Found $TMPCNT2 files in $TMPDIR2"
+echo "${BN}: Found ${TMPCNT1} files in ${TMPDIR1}"
+echo "${BN}: Found ${TMPCNT2} files in ${TMPDIR2}"
 
-if [ -f "$OUTLOG" ]; then
-	rm -f $OUTLOG
+if [ -f "${OUTLOG}" ]; then
+	rm -f "${OUTLOG}"
 fi
 
 TMPNOW=`d_now`
-echo "$BN: Compare of '$TMPDIR1' and '$TMPDIR2' on $TMPNOW" >> $OUTLOG
-echo "$BN: Found $TMPCNT1 files in $TMPDIR1" >> $OUTLOG
-echo "$BN: Found $TMPCNT2 files in $TMPDIR2" >> $OUTLOG
+echo "${BN}: Compare of '${TMPDIR1}' and '${TMPDIR2}' on ${TMPNOW}" >> "${OUTLOG}"
+echo "${BN}: Found ${TMPCNT1} files in ${TMPDIR1}" >> "${OUTLOG}"
+echo "${BN}: Found ${TMPCNT2} files in ${TMPDIR2}" >> "${OUTLOG}"
 
-for fil in $TMPDIR1/$TMPMASK; do
+for fil in "${TMPDIR1}"/${TMPMASK}; do
 	bfil=`basename $fil`
-	if [ -f "$TMPDIR2/$bfil" ]; then
-		diff $TMPDOP $TMPDIR1/$bfil $TMPDIR2/$bfil >> $OUTLOG
+	if [ -f "${TMPDIR2}/$bfil" ]; then
+		diff "${TMPDOP}" "${TMPDIR1}/$bfil" "${TMPDIR2}/$bfil" >> "${OUTLOG}"
 		if [ "$?" = "0" ]; then
-			echo "diff $TMPDOP $TMPDIR1/$bfil $TMPDIR2/$bfil are the SAME" >> $OUTLOG
-			SAMECNT=`expr $SAMECNT + 1`
+			echo "diff ${TMPDOP} ${TMPDIR1}/$bfil ${TMPDIR2}/$bfil are the SAME" >> "${OUTLOG}"
+			SAMECNT=`expr ${SAMECNT} + 1`
 		else
-			echo "diff $TMPDOP $TMPDIR1/$bfil $TMPDIR2/$bfil are DIFFERENT! *** CHECK DIFFERENCE ***" >> $OUTLOG
-			DIFFCNT=`expr $DIFFCNT + 1`
-			DIFFFILES="$DIFFFILES $bfil"
+			echo "diff ${TMPDOP} ${TMPDIR1}/$bfil ${TMPDIR2}/$bfil are DIFFERENT! *** CHECK DIFFERENCE ***" >> "${OUTLOG}"
+			DIFFCNT=`expr ${DIFFCNT} + 1`
+			DIFFFILES="${DIFFFILES} $bfil"
 		fi
 	else
-		echo "$BN: File $bfil not found in dir 2 $TMPDIR2" >> $OUTLOG
+		echo "${BN}: File $bfil not found in dir 2 ${TMPDIR2}" >> "${OUTLOG}"
 	fi
 done
-TOTCNT=`expr $SAMECNT + $DIFFCNT`
-echo "" >> $OUTLOG
-echo "$BN: Of the $TOTCNT compares made, $SAMECNT are the SAME, $DIFFCNT are DIFFERENT"
-echo "$BN: Of the $TOTCNT compares made, $SAMECNT are the SAME, $DIFFCNT are DIFFERENT" >> $OUTLOG
-if [ ! "$DIFFCNT" = "0" ]; then
-    echo "$BN: VERIFY $DIFFCNT $DIFFFILES"
-    echo "$BN: VERIFY $DIFFCNT $DIFFFILES" >> $OUTLOG
+TOTCNT=`expr ${SAMECNT} + ${DIFFCNT}`
+echo "" >> "${OUTLOG}"
+echo "${BN}: Of the ${TOTCNT} compares made, ${SAMECNT} are the SAME, ${DIFFCNT} are DIFFERENT"
+echo "${BN}: Of the ${TOTCNT} compares made, ${SAMECNT} are the SAME, ${DIFFCNT} are DIFFERENT" >> "${OUTLOG}"
+if [ ! "${DIFFCNT}" = "0" ]; then
+    echo "${BN}: VERIFY ${DIFFCNT} ${DIFFFILES}"
+    echo "${BN}: VERIFY ${DIFFCNT} ${DIFFFILES}" >> "${OUTLOG}"
 fi
-echo "" >> $OUTLOG
+echo "" >> "${OUTLOG}"
 
-echo "$BN: Full results are in $OUTLOG"
+echo "${BN}: Full results are in ${OUTLOG}"
 echo ""
 
 # eof
-

--- a/tools-sh/qo.sh
+++ b/tools-sh/qo.sh
@@ -9,16 +9,18 @@
 # Note it expects the -results folder to already exist.
 #=================================================================
 
+DIR="$(readlink -e $(dirname $0))"
+
 # setup the ENVIRONMENT
-source "_environment.sh"
+source "${DIR}/_environment.sh"
 set_environment
 
 # check critical inputs
 test_results_base_dir
 
-if [ $ERROR_COUNT -gt 0 ]; then
+if [ "${ERROR_COUNT}" -gt 0 ]; then
     echo ""
-    echo "$BN: Aborted. Please resolve the $ERROR_COUNT error(s), above."
+    echo "${BN}: Aborted. Please resolve the ${ERROR_COUNT} error(s), above."
     echo ""
     exit 1
 fi
@@ -40,64 +42,64 @@ give_help()
 # Check user input
 TMPCASE="$1"
 
-if [ -z "$TMPCASE" ]; then
+if [ -z "${TMPCASE}" ]; then
     give_help
     exit 1
 fi    
 
 # Find our case file
 TMPFIL="${TY_CASES_DIR}/case-${TMPCASE}.xhtml"
-if [ ! -f "$TMPFIL" ]; then
+if [ ! -f "${TMPFIL}" ]; then
 TMPFIL="${TY_CASES_DIR}/case-${TMPCASE}.xml"
 fi
-if [ ! -f "$TMPFIL" ]; then
+if [ ! -f "${TMPFIL}" ]; then
 TMPFIL="${TY_CASES_DIR}/case-${TMPCASE}.html"
 fi
-test_case_file "$TMPFIL" || exit 1
-bbedit "$TMPFIL"
+test_case_file "${TMPFIL}" || exit 1
+bbedit "${TMPFIL}"
 
 # Find our config file
 TMPFIL="${TY_CASES_DIR}/case-${TMPCASE}.conf"
-if [ ! -f "$TMPFIL" ]; then
+if [ ! -f "${TMPFIL}" ]; then
 TMPFIL="${TY_CONFIG_DEFAULT}"
 fi
-test_case_config "$TMPFIL"  || exit 1
-bbedit "$TMPFIL"
+test_case_config "${TMPFIL}"  || exit 1
+bbedit "${TMPFIL}"
 
 # Find our expects HTML file
 TMPFIL="${TY_EXPECTS_DIR}/case-${TMPCASE}.xhtml"
-if [ ! -f "$TMPFIL" ]; then
+if [ ! -f "${TMPFIL}" ]; then
 TMPFIL="${TY_EXPECTS_DIR}/case-${TMPCASE}.xml"
 fi
-if [ ! -f "$TMPFIL" ]; then
+if [ ! -f "${TMPFIL}" ]; then
 TMPFIL="${TY_EXPECTS_DIR}/case-${TMPCASE}.html"
 fi
-if [ -f "$TMPFIL" ]; then
-bbedit "$TMPFIL"
+if [ -f "${TMPFIL}" ]; then
+bbedit "${TMPFIL}"
 fi
 
 # Find our expects TXT file
 TMPFIL="${TY_EXPECTS_DIR}/case-${TMPCASE}.txt"
-if [ -f "$TMPFIL" ]; then
-bbedit "$TMPFIL"
+if [ -f "${TMPFIL}" ]; then
+bbedit "${TMPFIL}"
 fi
 
 # Find our results HTML file
 TMPFIL="${TY_RESULTS_DIR}/case-${TMPCASE}.xhtml"
-if [ ! -f "$TMPFIL" ]; then
+if [ ! -f "${TMPFIL}" ]; then
 TMPFIL="${TY_RESULTS_DIR}/case-${TMPCASE}.xml"
 fi
-if [ ! -f "$TMPFIL" ]; then
+if [ ! -f "${TMPFIL}" ]; then
 TMPFIL="${TY_RESULTS_DIR}/case-${TMPCASE}.html"
 fi
-if [ -f "$TMPFIL" ]; then
-bbedit "$TMPFIL"
+if [ -f "${TMPFIL}" ]; then
+bbedit "${TMPFIL}"
 fi
 
 # Find our results TXT file
 TMPFIL="${TY_RESULTS_DIR}/case-${TMPCASE}.txt"
-if [ -f "$TMPFIL" ]; then
-bbedit "$TMPFIL"
+if [ -f "${TMPFIL}" ]; then
+bbedit "${TMPFIL}"
 fi
 
 # eof

--- a/tools-sh/run-tests.sh
+++ b/tools-sh/run-tests.sh
@@ -1,54 +1,58 @@
 #!/usr/bin/env bash
 #< run-tests.sh - 20160309
 BN=`basename $0`
+DIR="$(readlink -e $(dirname $0))"
 
-TMPTIDY="../../tidy-html5/build/cmake/tidy"
-if [ ! -x "$TMPTIDY" ]; then
-	echo "$BN: Can NOT locate $TMPTIDY! *** FIX ME ***"
+TY_TIDY_PATH="${TY_TIDY_PATH:-"../../tidy-html5/build/cmake/tidy"}"
+if [ ! -x "${TY_TIDY_PATH}" ]; then
+	echo "${BN}: Can NOT locate ${TY_TIDY_PATH}! *** FIX ME ***"
 	exit 1
 fi
-TMPSCR="testall.sh"
-if [ ! -x "$TMPSCR" ]; then
-	echo "$BN: Can NOT locate $TMPSCR! *** FIX ME ***"
+TESTALL="${DIR}/testall.sh"
+if [ ! -x "${TESTALL}" ]; then
+	echo "${BN}: Can NOT locate ${TESTALL}! *** FIX ME ***"
 	exit 1
 fi
-TMPENV="_environment.sh"
-if [ ! -x "$TMPENV" ]; then
-	echo "$BN: Can NOT locate $TMPENV! *** FIX ME ***"
+TMPENV="${DIR}/_environment.sh"
+if [ ! -x "${TMPENV}" ]; then
+	echo "${BN}: Can NOT locate ${TMPENV}! *** FIX ME ***"
 	exit 1
 fi
 
 #set the ENVIRONMENT
 
-source "$TMPENV"
+source "${TMPENV}"
 set_environment
 #report_environment
 
-if [ ! -d "$TY_EXPECTS_DIR" ]; then
-	echo "$BN: Can NOT find the expects directory $TY_EXPECTS_DIR!"
+if [ ! -d "${TY_EXPECTS_DIR}" ]; then
+	echo "${BN}: Can NOT find the expects directory ${TY_EXPECTS_DIR}!"
 	exit 1
 fi
 
-./$TMPSCR $TMPTIDY
+"${TESTALL}" "${TY_TIDY_PATH}"
 
-if [ ! -d "$TY_RESULTS_DIR" ]; then
-	echo "$BN: Error: The results dir NOT created $TY_RESULTS_DIR"
+if [ ! -d "${TY_RESULTS_DIR}" ]; then
+	echo "${BN}: Error: The results dir NOT created ${TY_RESULTS_DIR}"
 	exit 1
 fi
 
-echo "$BN: Running 'diff -ua $TY_EXPECTS_DIR $TY_RESULTS_DIR'"
-echo "$BN: Running 'diff -ua $TY_EXPECTS_DIR $TY_RESULTS_DIR'" >> "${TY_RESULTS_FILE}"
+echo "${BN}: Running 'diff -ua ${TY_EXPECTS_DIR} ${TY_RESULTS_DIR}'"
+echo "${BN}: Running 'diff -ua ${TY_EXPECTS_DIR} ${TY_RESULTS_DIR}'" >> "${TY_RESULTS_FILE}"
 echo "======================================================" >> "${TY_RESULTS_FILE}"
-diff -ua "$TY_EXPECTS_DIR" "$TY_RESULTS_DIR" >> "${TY_RESULTS_FILE}"
-if [ "$?" = "0" ]; then
+diff -ua "${TY_EXPECTS_DIR}" "${TY_RESULTS_DIR}" >> "${TY_RESULTS_FILE}"
+STATUS=$?
+if [ "${STATUS}" = "0" ]; then
 	echo "======================================================" >> "${TY_RESULTS_FILE}"
-	echo "$BN: Appear to have PASSED test 2"
-	echo "$BN: Appear to have PASSED test 2" >> "${TY_RESULTS_FILE}"
+	echo "${BN}: Appear to have PASSED test 2"
+	echo "${BN}: Appear to have PASSED test 2" >> "${TY_RESULTS_FILE}"
 else
 	echo "======================================================" >> "${TY_RESULTS_FILE}"
-	echo "$BN: Appears test 2 FAILED!"
-	echo "$BN: Appears test 2 FAILED!" >> "${TY_RESULTS_FILE}"
+	echo "${BN}: Appears test 2 FAILED!"
+	echo "${BN}: Appears test 2 FAILED!" >> "${TY_RESULTS_FILE}"
 fi
-echo "$BN: See full results in $TY_RESULTS_FILE"
+echo "${BN}: See full results in ${TY_RESULTS_FILE}"
+
+exit "${STATUS}"
 
 # eof

--- a/tools-sh/t1.sh
+++ b/tools-sh/t1.sh
@@ -4,7 +4,7 @@
 # A convenient run one test giving the number and expected exit
 # 
 # This is to run just one, like "./t1.sh 1642186-1 0"
-# By default $TY_TIDY_PATH will be used. To use another, specify
+# By default ${TY_TIDY_PATH} will be used. To use another, specify
 # the path to a different tidy as the third argument, e.g.,
 # "./t1.sh 1642186-1 0 path/to/tidy"
 # 
@@ -17,17 +17,19 @@ if [ ! -z "$3" ]; then
     export TY_TIDY_PATH="$3"
 fi
 
+DIR="$(readlink -e $(dirname $0))"
+
 # setup the ENVIRONMENT
-source "_environment.sh"
+source "${DIR}/_environment.sh"
 set_environment
 
 # check critical inputs
 test_results_base_dir
 test_tidy_path
 
-if [ $ERROR_COUNT -gt 0 ]; then
+if [ "${ERROR_COUNT}" -gt 0 ]; then
     echo ""
-    echo "$BN: Aborted. Please resolve the $ERROR_COUNT error(s), above."
+    echo "${BN}: Aborted. Please resolve the ${ERROR_COUNT} error(s), above."
     echo ""
     exit 1
 fi
@@ -55,38 +57,38 @@ TMPCASE="$1"
 TMPEXIT="$2"
 TMPNOW=`d_now`
 
-if [ -z "$TMPCASE" ]; then
+if [ -z "${TMPCASE}" ]; then
     give_help
     exit 1
 fi    
-if [ -z "$TMPEXIT" ]; then
+if [ -z "${TMPEXIT}" ]; then
     give_help
     exit 1
 fi
 
 # Find our case file and its config file, and verify them.
 TMPFIL="${TY_CASES_DIR}/case-${TMPCASE}.xhtml"
-if [ ! -f "$TMPFIL" ]; then
+if [ ! -f "${TMPFIL}" ]; then
 TMPFIL="${TY_CASES_DIR}/case-${TMPCASE}.xml"
 fi
-if [ ! -f "$TMPFIL" ]; then
+if [ ! -f "${TMPFIL}" ]; then
 TMPFIL="${TY_CASES_DIR}/case-${TMPCASE}.html"
 fi
 TMPCFG="${TY_CASES_DIR}/case-${TMPCASE}.conf"
-if [ ! -f "$TMPCFG" ]; then
+if [ ! -f "${TMPCFG}" ]; then
 TMPCFG="${TY_CONFIG_DEFAULT}"
 fi
 
-test_case_file "$TMPFIL" || exit 1
-test_case_config "$TMPCFG"  || exit 1
+test_case_file "${TMPFIL}" || exit 1
+test_case_config "${TMPCFG}"  || exit 1
 
 
 # Start logging.
 if [ -f "${TY_RESULTS_FILE}" ]; then
     rm -f ${TY_RESULTS_FILE}
 fi
-echo "$BN: Test 1 case $TMPCASE $TMPEXIT on $TMPNOW" > "${TY_RESULTS_FILE}"
-echo "$BN: Version of tidy in use..." >> "${TY_RESULTS_FILE}"
+echo "${BN}: Test 1 case ${TMPCASE} ${TMPEXIT} on ${TMPNOW}" > "${TY_RESULTS_FILE}"
+echo "${BN}: Version of tidy in use..." >> "${TY_RESULTS_FILE}"
 version=$(report_tidy_version) || exit 1
 echo ${version} >> "${TY_RESULTS_FILE}"
 version=$(report_testbase_version)
@@ -94,9 +96,9 @@ echo ${version} >> "${TY_RESULTS_FILE}"
 
 
 echo ""
-echo "$BN: Doing './testone.sh $TMPCASE $TMPEXIT'"
-echo "$BN: Doing './testone.sh $TMPCASE $TMPEXIT'" >> "${TY_RESULTS_FILE}"
-echo "$BN: testone.sh run '${TY_TIDY_PATH} ... -config $TMPCFG $TMPFIL'" >> "${TY_RESULTS_FILE}"
+echo "${BN}: Doing '${DIR}/testone.sh ${TMPCASE} ${TMPEXIT}'"
+echo "${BN}: Doing '${DIR}/testone.sh ${TMPCASE} ${TMPEXIT}'" >> "${TY_RESULTS_FILE}"
+echo "${BN}: testone.sh run '${TY_TIDY_PATH} ... -config ${TMPCFG} ${TMPFIL}'" >> "${TY_RESULTS_FILE}"
 
 # Clear the temporary results file.
 if [ -f "${TY_TMP_FILE}" ]; then
@@ -104,7 +106,7 @@ if [ -f "${TY_TMP_FILE}" ]; then
 fi
 
 # Run the test
-./testone.sh $TMPCASE $TMPEXIT
+"${DIR}/testone.sh" "${TMPCASE}" "${TMPEXIT}"
 
 # Append test results to the log.
 if [ -f "${TY_TMP_FILE}" ]; then
@@ -116,29 +118,29 @@ else
 fi
 
 echo ""
-echo "$BN: See output in ${TY_RESULTS_FILE}"
+echo "${BN}: See output in ${TY_RESULTS_FILE}"
 echo ""
 
 # Start the comparison phase
-echo "$BN: Checking for compare phase..." >> "${TY_RESULTS_FILE}"
+echo "${BN}: Checking for compare phase..." >> "${TY_RESULTS_FILE}"
 
 TMPFIL1="${TY_EXPECTS_DIR}/case-${TMPCASE}.html"
 TMPOUT1="${TY_EXPECTS_DIR}/case-${TMPCASE}.txt"
 TMPFIL2="${TY_RESULTS_DIR}/case-${TMPCASE}.html"
 TMPOUT2="${TY_RESULTS_DIR}/case-${TMPCASE}.txt"
 
-test_file_expects $TMPFIL1 $TMPCASE
-test_file_expects $TMPOUT1 $TMPCASE
-test_file_output $TMPFIL2
-test_file_output $TMPOUT2
-if [ $ERROR_COUNT -gt 0 ]; then exit 1; fi
+test_file_expects "${TMPFIL1}" "${TMPCASE}"
+test_file_expects "${TMPOUT1}" "${TMPCASE}"
+test_file_output "${TMPFIL2}"
+test_file_output "${TMPOUT2}"
+if [ "${ERROR_COUNT}" -gt 0 ]; then exit 1; fi
 
 
 is_diff()
 {
     echo ""
-    echo "$BN: Check the above diff carefully. This may indicate a 'testbase', or"
-    echo "$BN: a 'regression' in tidy output."
+    echo "${BN}: Check the above diff carefully. This may indicate a 'testbase', or"
+    echo "${BN}: a 'regression' in tidy output."
     echo ""
 }
 
@@ -148,37 +150,37 @@ TMPOPTS="-ua"
 ERRCNT=0
 
 echo ""
-echo "$BN: Doing: 'diff $TMPOPTS $TMPFIL1 $TMPFIL2'"
-echo "$BN: Doing: 'diff $TMPOPTS $TMPFIL1 $TMPFIL2'" >> "${TY_RESULTS_FILE}"
-diff $TMPOPTS $TMPFIL1 $TMPFIL2
+echo "${BN}: Doing: 'diff ${TMPOPTS} ${TMPFIL1} ${TMPFIL2}'"
+echo "${BN}: Doing: 'diff ${TMPOPTS} ${TMPFIL1} ${TMPFIL2}'" >> "${TY_RESULTS_FILE}"
+diff ${TMPOPTS} ${TMPFIL1} ${TMPFIL2}
 if [ "$?" = "0" ]; then
     echo "Files appear exactly the same..."
 else
     is_diff
-    ERRCNT=`expr $ERRCNT + 1`
+    ERRCNT=`expr ${ERRCNT} + 1`
 fi
 
 echo ""
-echo "$BN: Doing: 'diff $TMPOPTS $TMPOUT1 $TMPOUT2'"
-echo "$BN: Doing: 'diff $TMPOPTS $TMPOUT1 $TMPOUT2'" >> "${TY_RESULTS_FILE}"
-diff $TMPOPTS $TMPOUT1 $TMPOUT2
+echo "${BN}: Doing: 'diff ${TMPOPTS} ${TMPOUT1} ${TMPOUT2}'"
+echo "${BN}: Doing: 'diff ${TMPOPTS} ${TMPOUT1} ${TMPOUT2}'" >> "${TY_RESULTS_FILE}"
+diff ${TMPOPTS} ${TMPOUT1} ${TMPOUT2}
 if [ "$?" = "0" ]; then
-    echo "$BN: Files appear exactly the same..."
+    echo "${BN}: Files appear exactly the same..."
 else
     is_diff
-    ERRCNT=`expr $ERRCNT + 1`
+    ERRCNT=`expr ${ERRCNT} + 1`
 fi
 
 echo ""
-if [ "$ERRCNT" = "0" ]; then
-    echo "$BN: Appears a successful test of $TMPCASE $TMPEXIT"
-    echo "$BN: Appears a successful test of $TMPCASE $TMPEXIT" >> "${TY_RESULTS_FILE}"
+if [ "${ERRCNT}" = "0" ]; then
+    echo "${BN}: Appears a successful test of ${TMPCASE} ${TMPEXIT}"
+    echo "${BN}: Appears a successful test of ${TMPCASE} ${TMPEXIT}" >> "${TY_RESULTS_FILE}"
 else
-    echo "$BN: Carefully REVIEW the above differences on $TMPCASE $TMPEXIT! *** ACTION REQUIRED ***"
-    echo "$BN: Carefully REVIEW the above differences on $TMPCASE $TMPEXIT! *** ACTION REQUIRED ***" >> "${TY_RESULTS_FILE}"
+    echo "${BN}: Carefully REVIEW the above differences on ${TMPCASE} ${TMPEXIT}! *** ACTION REQUIRED ***"
+    echo "${BN}: Carefully REVIEW the above differences on ${TMPCASE} ${TMPEXIT}! *** ACTION REQUIRED ***" >> "${TY_RESULTS_FILE}"
 fi
 echo ""
 echo "# eof" >> "${TY_RESULTS_FILE}"
-echo "$BN: See full ouput in ${TY_RESULTS_FILE}"
+echo "${BN}: See full ouput in ${TY_RESULTS_FILE}"
 
 # eof

--- a/tools-sh/testaccess.sh
+++ b/tools-sh/testaccess.sh
@@ -10,11 +10,13 @@
 #=================================================================
 
 # Change our set name for this test.
-original_set="$TY_CASES_SETNAME"
+original_set="${TY_CASES_SETNAME}"
 export TY_CASES_SETNAME="access"
 
+DIR="$(readlink -e $(dirname $0))"
+
 # setup the ENVIRONMENT
-source "_environment.sh"
+source "${DIR}/_environment.sh"
 set_environment
 
 # check critical inputs
@@ -22,7 +24,7 @@ test_results_base_dir || exit 1
 test_tidy_path || exit 1
 
 
-VERSION='$Id'
+VERSION='${Id}'
 
 if [ -f "${TY_RESULTS_FILE}" ]; then
     rm "${TY_RESULTS_FILE}"
@@ -30,11 +32,11 @@ fi
 
 cat "${TY_EXPECTS_FILE}" | sed 1d | \
 {
-while read bugNo expected
+while read bugNo expected accessLevel
 do
-    ./testaccessone.sh $bugNo $expected "$@" | tee -a "${TY_RESULTS_FILE}"
+    "${DIR}/testaccessone.sh" "${bugNo}" "${expected}" "${accessLevel}" | tee -a "${TY_RESULTS_FILE}"
 done
 }
 
 # Restore the original set name
-export TY_CASES_SETNAME="$original_set"
+export TY_CASES_SETNAME="${original_set}"

--- a/tools-sh/testaccessone.sh
+++ b/tools-sh/testaccessone.sh
@@ -15,23 +15,25 @@ if [ "$#" -ne 3 ]; then
     exit
 fi
 
+DIR="$(readlink -e $(dirname $0))"
+
 # setup the ENVIRONMENT
-source "_environment.sh"
+source "${DIR}/_environment.sh"
 set_environment
 
 # check critical inputs
 test_results_base_dir || exit 1
 test_tidy_path || exit 1
 
-VERSION='$Id'
+VERSION='${Id}'
 
-echo Testing $1
+echo "Testing $1"
 
 set +f
 
-TESTNO=$1
-TESTEXPECTED=$2
-ACCESSLEVEL=$3
+TESTNO="$1"
+TESTEXPECTED="$2"
+ACCESSLEVEL="$3"
 
 INFILES="${TY_CASES_DIR}/case-$1.*ml"
 CFGFILE="${TY_CASES_DIR}/case-$1.conf"
@@ -46,24 +48,24 @@ shift
 shift
 
 # Remove any pre-exising test outputs
-for INFIL in $MSGFILE $TIDYFILE
+for INFIL in "${MSGFILE}" "${TIDYFILE}"
 do
-  if [ -f $INFIL ]
+  if [ -f "${INFIL}" ]
   then
-    rm $INFIL
+    rm "${INFIL}"
   fi
 done
 
-for INFILE in $INFILES
+for INFILE in ${INFILES}
 do
-    if [ -r $INFILE ]
+    if [ -r "${INFILE}" ]
     then
       break
     fi
 done
 
 # If no test specific config file, use default.
-if [ ! -f $CFGFILE ]
+if [ ! -f "${CFGFILE}" ]
 then
   CFGFILE="${TY_CONFIG_DEFAULT}"
 fi
@@ -74,15 +76,14 @@ if [ ! -d "${TY_RESULTS_DIR}" ]; then
 fi
 
 # Perform the testing
-${TY_TIDY_PATH} -f $MSGFILE --accessibility-check $ACCESSLEVEL -config $CFGFILE "$@" --gnu-emacs yes --tidy-mark no -o $TIDYFILE $INFILE
+"${TY_TIDY_PATH}" -f "${MSGFILE}" --accessibility-check "${ACCESSLEVEL}" -config "${CFGFILE}" "$@" --gnu-emacs yes --tidy-mark no -o "${TIDYFILE}" "${INFILE}"
 STATUS=$?
 
-if [ `grep -c -e ' \['$TESTEXPECTED'\]: ' $MSGFILE` = 0 ]
+if [ `grep -c -e ' \['${TESTEXPECTED}'\]: ' "${MSGFILE}"` = 0 ]
 then
-  echo "--- test '$TESTEXPECTED' not detected in file '$INFILE'"
-  cat $MSGFILE
+  echo "--- test '${TESTEXPECTED}' not detected in file '${INFILE}'"
+  cat "${MSGFILE}"
   exit 1
 fi
 
 exit 0
-

--- a/tools-sh/testall.sh
+++ b/tools-sh/testall.sh
@@ -15,8 +15,10 @@ if [ ! -z "$1" ]; then
     export TY_TIDY_PATH="$1"
 fi
 
+DIR="$(readlink -e $(dirname $0))"
+
 # setup the ENVIRONMENT
-source "_environment.sh"
+source "${DIR}/_environment.sh"
 set_environment
 
 # check critical inputs
@@ -26,25 +28,26 @@ test_tidy_path || exit 1
 
 TMPNOW=`d_now`
 TMPINP="${TY_EXPECTS_FILE}"
+TESTONE="${DIR}/testone.sh"
 
-test_file_general "testone.sh" || exit 1
-test_file_general "$TMPINP" || exit 1
+test_file_general "${TESTONE}" || exit 1
+test_file_general "${TMPINP}" || exit 1
 
 
 # count the tests
 TMPCNT=0
 while read bugNo expected
 do
-    TMPCNT=`expr $TMPCNT + 1`
-done < $TMPINP
+    TMPCNT=`expr ${TMPCNT} + 1`
+done < ${TMPINP}
 
 # output a header
 if [ -f "${TY_RESULTS_FILE}" ]; then
 	rm -f ${TY_RESULTS_FILE}
 fi
-echo "$BN: Will process $TMPCNT tests from $TMPINP on $TMPNOW"
-echo "$BN: Will process $TMPCNT tests from $TMPINP on $TMPNOW" > "${TY_RESULTS_FILE}"
-echo "$BN: Tidy version in use..." >> "${TY_RESULTS_FILE}"
+echo "${BN}: Will process ${TMPCNT} tests from ${TMPINP} on ${TMPNOW}"
+echo "${BN}: Will process ${TMPCNT} tests from ${TMPINP} on ${TMPNOW}" > "${TY_RESULTS_FILE}"
+echo "${BN}: Tidy version in use..." >> "${TY_RESULTS_FILE}"
 version=$(report_tidy_version) || exit 1
 echo ${version} >> "${TY_RESULTS_FILE}"
 version=$(report_testbase_version)
@@ -56,14 +59,13 @@ echo "========================================" >> "${TY_RESULTS_FILE}"
 while read bugNo expected
 do
 #  echo Testing $bugNo | tee -a "${TY_RESULTS_FILE}"
-  ./testone.sh $bugNo $expected | tee -a "${TY_RESULTS_FILE}"
-done < $TMPINP
+  "${TESTONE}" $bugNo $expected | tee -a "${TY_RESULTS_FILE}"
+done < ${TMPINP}
 echo "========================================" >> "${TY_RESULTS_FILE}"
 
-echo "$BN: Done $TMPCNT tests..." >> "${TY_RESULTS_FILE}"
+echo "${BN}: Done ${TMPCNT} tests..." >> "${TY_RESULTS_FILE}"
 echo "# eof"
-echo "$BN: Done $TMPCNT tests - see ${TY_RESULTS_FILE}"
+echo "${BN}: Done ${TMPCNT} tests - see ${TY_RESULTS_FILE}"
 
 
 # eof
-

--- a/tools-sh/testone.sh
+++ b/tools-sh/testone.sh
@@ -18,15 +18,17 @@ if [ "$#" -ne 2 ]; then
     exit
 fi
 
+DIR="$(readlink -e $(dirname $0))"
+
 # setup the ENVIRONMENT
-source "_environment.sh"
+source "${DIR}/_environment.sh"
 set_environment
 
 # check critical inputs
 test_results_base_dir || exit 1
 test_tidy_path || exit 1
 
-echo Testing $1
+echo "Testing $1"
 set +f # ensure wildcard expansion is on
 
 TESTNO=$1
@@ -39,24 +41,24 @@ TIDYFILE="${TY_RESULTS_DIR}/case-${TESTNO}.html"
 MSGFILE="${TY_RESULTS_DIR}/case-${TESTNO}.txt"
 
 # Remove any pre-exising test outputs
-for INFIL in $MSGFILE $TIDYFILE
+for INFIL in "${MSGFILE}" "${TIDYFILE}"
 do
-  if [ -f $INFIL ]
+  if [ -f "${INFIL}" ]
   then
-    rm $INFIL
+    rm "${INFIL}"
   fi
 done
 
-for INFILE in $INFILES
+for INFILE in ${INFILES}
 do
-    if [ -r $INFILE ]
+    if [ -r "${INFILE}" ]
     then
       break
     fi
 done
 
 # If no test specific config file, use default.
-if [ ! -f $CFGFILE ]
+if [ ! -f "${CFGFILE}" ]
 then
   CFGFILE="${TY_CONFIG_DEFAULT}"
 fi
@@ -76,22 +78,21 @@ shift
 shift
 
 # Execute the test
-echo "Doing: '${TY_TIDY_PATH} -lang en_us -f $MSGFILE -config $CFGFILE "$@" --tidy-mark no -o $TIDYFILE $INFILE'" >> "${TY_TMP_FILE}"
-${TY_TIDY_PATH} -lang en_us -f $MSGFILE -config $CFGFILE "$@" --tidy-mark no -o $TIDYFILE $INFILE
+echo "Doing: '${TY_TIDY_PATH} -lang en_us -f ${MSGFILE} -config ${CFGFILE} "$@" --tidy-mark no -o ${TIDYFILE} ${INFILE}'" >> "${TY_TMP_FILE}"
+"${TY_TIDY_PATH}" -lang en_us -f "${MSGFILE}" -config "${CFGFILE}" "$@" --tidy-mark no -o "${TIDYFILE}" "${INFILE}"
 STATUS=$?
 
-if [ $STATUS -ne $EXPECTED ]
+if [ "${STATUS}" -ne "${EXPECTED}" ]
 then
-  echo "== $TESTNO failed (Status received: $STATUS vs expected: $EXPECTED)"
+  echo "== ${TESTNO} failed (Status received: ${STATUS} vs expected: ${EXPECTED})"
   echo ""
-  cat $MSGFILE
-  echo "== $TESTNO failed (Status received: $STATUS vs expected: $EXPECTED)" >> "${TY_TMP_FILE}"
+  cat "${MSGFILE}"
+  echo "== ${TESTNO} failed (Status received: ${STATUS} vs expected: ${EXPECTED})" >> "${TY_TMP_FILE}"
   echo ""
-  cat $MSGFILE >> "${TY_TMP_FILE}"
+  cat "${MSGFILE}" >> "${TY_TMP_FILE}"
   exit 1
 fi
 
 exit 0
 
 # eof
-

--- a/tools-sh/testspl.sh
+++ b/tools-sh/testspl.sh
@@ -11,18 +11,22 @@
 
 # Allow user-supplied Tidy via command line. Note that setting
 # the TY_TIDY_PATH environment variable is a valid alternative.
-if [ -z "$1" ]; then
-    export TY_TIDY_PATH="../../tidy-html5/build/cmake/tidy"
-else
-    export TY_TIDY_PATH="$1"
+if [ -z "${TY_TIDY_PATH}" ]; then
+    if [ -z "$1" ]; then
+        export TY_TIDY_PATH="../../tidy-html5/build/cmake/tidy"
+    else
+        export TY_TIDY_PATH="$1"
+    fi
 fi
 
 # Change our set name for this test.
-original_set="$TY_CASES_SETNAME"
+original_set="${TY_CASES_SETNAME}"
 export TY_CASES_SETNAME="special"
 
+DIR="$(readlink -e $(dirname $0))"
+
 # setup the ENVIRONMENT
-source "_environment.sh"
+source "${DIR}/_environment.sh"
 set_environment
 # report_environment
 
@@ -30,33 +34,32 @@ set_environment
 test_results_base_dir || exit 1
 test_tidy_path || exit 1
 
-if [ -f "$TY_RESULTS_FILE" ]; then
-    rm -fv $TY_RESULTS_FILE
+if [ -f "${TY_RESULTS_FILE}" ]; then
+    rm -fv ${TY_RESULTS_FILE}
 fi
 
 while read bugNo expected
 do
-  # echo "Testing $bugNo $expected"
-  ./testone.sh "$bugNo" "$expected" | tee -a "${TY_RESULTS_FILE}"
+  # echo "Testing ${bugNo} ${expected}"
+  "${DIR}/testone.sh" "${bugNo}" "${expected}" | tee -a "${TY_RESULTS_FILE}"
 done < "${TY_EXPECTS_FILE}"
 
-echo "$BN: Running 'diff -ua $TY_EXPECTS_DIR $TY_RESULTS_DIR'"
-echo "$BN: Running 'diff -ua $TY_EXPECTS_DIR $TY_RESULTS_DIR'" >> "${TY_RESULTS_FILE}"
+echo "${BN}: Running 'diff -ua ${TY_EXPECTS_DIR} ${TY_RESULTS_DIR}'"
+echo "${BN}: Running 'diff -ua ${TY_EXPECTS_DIR} ${TY_RESULTS_DIR}'" >> "${TY_RESULTS_FILE}"
 echo "======================================================" >> "${TY_RESULTS_FILE}"
-diff -ua "$TY_EXPECTS_DIR" "$TY_RESULTS_DIR" >> "${TY_RESULTS_FILE}"
+diff -ua "${TY_EXPECTS_DIR}" "${TY_RESULTS_DIR}" >> "${TY_RESULTS_FILE}"
 if [ "$?" = "0" ]; then
 	echo "======================================================" >> "${TY_RESULTS_FILE}"
-	echo "$BN: Appear to have PASSED test 2"
-	echo "$BN: Appear to have PASSED test 2" >> "${TY_RESULTS_FILE}"
+	echo "${BN}: Appear to have PASSED test 2"
+	echo "${BN}: Appear to have PASSED test 2" >> "${TY_RESULTS_FILE}"
 else
 	echo "======================================================" >> "${TY_RESULTS_FILE}"
-	echo "$BN: Appears test 2 FAILED!"
-	echo "$BN: Appears test 2 FAILED!" >> "${TY_RESULTS_FILE}"
+	echo "${BN}: Appears test 2 FAILED!"
+	echo "${BN}: Appears test 2 FAILED!" >> "${TY_RESULTS_FILE}"
 fi
-echo "$BN: See full results in $TY_RESULTS_FILE"
+echo "${BN}: See full results in ${TY_RESULTS_FILE}"
 
 # Restore the original set name
-export TY_CASES_SETNAME="$original_set"
+export TY_CASES_SETNAME="${original_set}"
 
 # eof
-

--- a/tools-sh/testxml.sh
+++ b/tools-sh/testxml.sh
@@ -16,11 +16,13 @@ if [ ! -z "$1" ]; then
 fi
 
 # Change our set name for this test.
-original_set="$TY_CASES_SETNAME"
+original_set="${TY_CASES_SETNAME}"
 export TY_CASES_SETNAME="xml"
 
+DIR="$(readlink -e $(dirname $0))"
+
 # setup the ENVIRONMENT
-source "_environment.sh"
+source "${DIR}/_environment.sh"
 set_environment
 
 # check critical inputs
@@ -28,14 +30,14 @@ test_results_base_dir || exit 1
 test_tidy_path || exit 1
 
 
-VERSION='$Id'
+VERSION='${Id}'
 BUGS="427837 431956 433604 433607 433670 434100\
  480406 480701 500236 503436 537604 616744 640474 646946"
 
 while read bugNo expected
 do
-#  echo Testing $bugNo | tee -a testxml.log
-  ./testone.sh "$bugNo" "$expected" "$@" | tee -a "${TY_RESULTS_FILE}"
+#  echo Testing ${bugNo} | tee -a testxml.log
+  "${DIR}/testone.sh" "${bugNo}" "${expected}" | tee -a "${TY_RESULTS_FILE}"
   if test -f "${TY_RESULTS_DIR}/case-${bugNo}.html"
   then
     mv "${TY_RESULTS_DIR}/case-${bugNo}.html" "${TY_RESULTS_DIR}/case-${bugNo}.xml"
@@ -43,4 +45,4 @@ do
 done < "${TY_EXPECTS_FILE}"
 
 # Restore the original set name
-export TY_CASES_SETNAME="$original_set"
+export TY_CASES_SETNAME="${original_set}"


### PR DESCRIPTION
This change updates the bash scripts so that they can be invoked from an
arbitrary path. It also tries to be consistent of using braced, quoted
variables.

This is needed to fix https://github.com/htacg/tidy-html5/issues/545